### PR TITLE
Add support for the TTGO T-Display board using TFT_eSPI

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,9 @@ monitor_port = /dev/cu.wch*
 ; These are true for a good chunk of the OLED devices I've tried on MacOS. Again - probably won't work for other platforms.
 ;upload_port = /dev/cu.SLAB_USBtoUART
 ;monitor_port = /dev/cu.SLAB_USBtoUART
+; These are true for the TTGO T-Display connected via USB to USB-C cable to a Mac
+;upload_port = /dev/cu.usb*
+;monitor_port = /dev/cu.usb*
 
 ; -D_GLIBCXX_USE_C99 is to fix an issue with the xtensa toolchain that precludes the use of std::to_string
 ; See: https://github.com/espressif/esp-idf/issues/1445

--- a/platformio.ini
+++ b/platformio.ini
@@ -132,7 +132,6 @@ build_flags =
     ${common.build_flags}
     -DLCD_TFT_ESPI
     -DDISABLE_OTA_UPDATES
-    -DDEBUG_PRINTS
     -DUSER_SETUP_LOADED=1
     -DST7789_DRIVER=1
     -DTFT_WIDTH=135

--- a/platformio.ini
+++ b/platformio.ini
@@ -113,3 +113,43 @@ monitor_speed = ${common.monitor_speed}
 upload_port = ${common.upload_port}
 monitor_port = ${common.monitor_port}
 
+
+[env:tft_espi]
+; This is configured for a TTGO T-Display using the tft_espi drivers
+; it should work for other tft_espi compatible displays, if you tweak
+; the defines appropriately. See the documentation for TFT_eSPI at
+; https://github.com/Bodmer/TFT_eSPI
+platform = ${common.platform}
+board = esp32dev
+framework = ${common.framework}
+; The T-Display has 4MB of flash. Use huge_app to get us the space - but
+; at the cost of being able to update OTA.
+board_build.partitions = huge_app.csv
+build_flags =
+    ${common.build_flags}
+    -DLCD_TFT_ESPI
+    -DDISABLE_OTA_UPDATES
+    -DDEBUG_PRINTS
+    -DUSER_SETUP_LOADED=1
+    -DST7789_DRIVER=1
+    -DTFT_WIDTH=135
+    -DTFT_HEIGHT=240
+    -DCGRAM_OFFSET=1
+    -DTFT_MISO=-1
+    -DTFT_MOSI=19
+    -DTFT_SCLK=18
+    -DTFT_CS=5
+    -DTFT_DC=16
+    -DTFT_RST=23
+    -DTFT_BL=4
+    -DTFT_BACKLIGHT_ON=1
+    -DLOAD_GLCD=1
+    -DLOAD_FONT4=1
+lib_deps =
+    ${common.lib_deps}
+    TFT_eSPI
+upload_speed = ${common.upload_speed}
+monitor_speed = ${common.monitor_speed}
+upload_port = ${common.upload_port}
+monitor_port = ${common.monitor_port}
+

--- a/src/bridge_lcd.cpp
+++ b/src/bridge_lcd.cpp
@@ -140,7 +140,11 @@ void bridge_lcd::display_wifi_connect_screen(String ap_name, String ap_pass) {
 void bridge_lcd::display_wifi_success_screen(const String& mdns_url, const String& ip_address_url) {
     // This screen is displayed at startup when the TiltBridge is configured to connect to WiFi
     clear();
+#ifdef LCD_TFT_ESPI
+    print_line("Access TiltBridge at:", "", 1);
+#else
     print_line("Access your TiltBridge at:", "", 1);
+#endif
     print_line(mdns_url, "", 2);
     print_line(ip_address_url, "", 3);
     display();

--- a/src/bridge_lcd.cpp
+++ b/src/bridge_lcd.cpp
@@ -16,6 +16,10 @@ bridge_lcd lcd;
 #include "img/tiltbridge_logo_tft.h"  // The (large) TiltBridge logo
 #endif
 
+#ifdef LCD_TFT_ESPI
+#include "img/fermentrack_logo.h"  // We're only using this style of logo for the OLED variant
+#endif
+
 
 bridge_lcd::bridge_lcd() {
     next_screen_at = 0;
@@ -42,6 +46,11 @@ void bridge_lcd::display_logo() {
     tft->drawRGBBitmap((320-288)/2, 0, gimp_image.pixel_data, gimp_image.width, gimp_image.height);
 #endif
 
+#ifdef LCD_TFT_ESPI
+    clear();
+    tft->drawXBitmap((tft->width()-fermentrack_logo_width)/2, (tft->height()-fermentrack_logo_height)/2, fermentrack_logo_bits, fermentrack_logo_width, fermentrack_logo_height, TFT_WHITE);
+    display();
+#endif
 }
 
 
@@ -142,7 +151,8 @@ void bridge_lcd::display_wifi_reset_screen() {
     // while this screen is displayed, WiFi settings are cleared and the TiltBridge will return to displaying the
     // configuration AP at startup
     clear();
-#ifdef LCD_SSD1306
+ 
+#if defined(LCD_SSD1306) || defined(LCD_TFT_ESPI)
     print_line("Press the button again to", "", 1);
     print_line("disable autoconnection", "", 2);
     print_line("and start the WiFi ", "", 3);
@@ -274,6 +284,14 @@ void bridge_lcd::init() {
 
 #endif
 
+#ifdef LCD_TFT_ESPI
+    tft = new TFT_eSPI(TFT_WIDTH, TFT_HEIGHT);
+    tft->init();
+    tft->fontHeight(TFT_ESPI_FONT_HEIGHT);
+    tft->setRotation(1);
+    tft->fillScreen(TFT_BLACK);
+#endif
+
 }
 
 
@@ -285,6 +303,10 @@ void bridge_lcd::clear() {
 
 #ifdef LCD_TFT
     tft->fillScreen(ILI9341_BLACK);
+#endif
+
+#ifdef LCD_TFT_ESPI
+    tft->fillScreen(TFT_BLACK);
 #endif
 
 }
@@ -340,6 +362,17 @@ void bridge_lcd::print_line(const String& left_text, const String& middle_text, 
     tft->setCursor(320-w,y);
     tft->print(right_text);
 
+#endif
+
+#ifdef LCD_TFT_ESPI
+    // middle_text is ignored for non-TFT displays
+    int16_t starting_pixel_row = 0;
+
+    starting_pixel_row = (TFT_ESPI_LINE_CLEARANCE + TFT_ESPI_FONT_SIZE) * (line-1) + TFT_ESPI_LINE_CLEARANCE;
+
+    // TFT_eSPI::drawString(const char *string, int32_t poX, int32_t poY, uint8_t font_number)
+    tft->drawString(left_text, 0, starting_pixel_row, TFT_ESPI_FONT_NUMBER);
+    tft->drawString(right_text, tft->width()/2, starting_pixel_row, TFT_ESPI_FONT_NUMBER);
 #endif
 
 }

--- a/src/bridge_lcd.h
+++ b/src/bridge_lcd.h
@@ -34,6 +34,17 @@
 #define TILTS_PER_PAGE          15  // The actual number is one fewer than this - the first row is used for headers
 #define TILT_FONT_SIZE          2
 
+#elif defined(LCD_TFT_ESPI)
+
+#include <TFT_eSPI.h> 
+#include <SPI.h>
+
+#define TFT_ESPI_FONT_SIZE      25
+#define TFT_ESPI_LINE_CLEARANCE 4
+#define TFT_ESPI_FONT_HEIGHT    2
+#define TFT_ESPI_FONT_NUMBER    4
+#define TILTS_PER_PAGE          3  // The actual number is one fewer than this - the first row is used for headers
+
 #endif
 
 
@@ -76,6 +87,8 @@ private:
     SSD1306* oled_display;
 #elif defined(LCD_TFT)
     Adafruit_ILI9341* tft;
+#elif defined(LCD_TFT_ESPI)
+    TFT_eSPI* tft;
 #endif
 
     uint8_t tilt_pages_in_run;  // Number of pages in the current loop through the active tilts (# active tilts / 3)

--- a/src/bridge_lcd.h
+++ b/src/bridge_lcd.h
@@ -43,7 +43,7 @@
 #define TFT_ESPI_LINE_CLEARANCE 4
 #define TFT_ESPI_FONT_HEIGHT    2
 #define TFT_ESPI_FONT_NUMBER    4
-#define TILTS_PER_PAGE          3  // The actual number is one fewer than this - the first row is used for headers
+#define TILTS_PER_PAGE          4  // The actual number is one fewer than this - the first row is used for headers
 
 #endif
 

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -205,7 +205,7 @@ void reconnectIfDisconnected() {
         {
             delay( 100 );
 #ifdef DEBUG_PRINTS
-            if(WLcount % 5 = 0)
+            if(WLcount % 5 == 0)
                 Serial.printf(".");
 #endif
             ++WLcount;


### PR DESCRIPTION
This pull request adds display support for the https://github.com/Xinyuan-LilyGO/TTGO-T-Display board using the https://github.com/Bodmer/TFT_eSPI library.

I also fixed a typo in wifi_setup.cpp that is triggered only when debugging print statements are turned on:
```
src/wifi_setup.cpp:208:28: error: lvalue required as left operand of assignment
             if(WLcount % 5 = 0)
                            ^
```