### PR TITLE
Implement pushing to BrewStatus

### DIFF
--- a/data/settings.htm
+++ b/data/settings.htm
@@ -318,6 +318,16 @@
                             </div>
                         </form>
 
+                        <form action="/settings/update/" method="POST">
+                            <div class="form-group row">
+                                <label for="brewstatusTZoffset" class="col-sm-2 col-form-label" data-toggle="tooltip" title="Time zone offset from UTC (in hours)">Time Zone Offset</label>
+                                <div class="col-sm-8">
+                                    <input type="text" class="form-control" name="brewstatusTZoffset" id="brewstatusTZoffset" placeholder="-5" :value="settings.brewstatusTZoffset">
+                                </div>
+                                <div class="col-sm-2"><button type="submit" class="btn btn-primary">Update</button></div>
+                            </div>
+                        </form>
+
                     </div>
                 </div>
             </div>

--- a/data/settings.htm
+++ b/data/settings.htm
@@ -287,6 +287,42 @@
         </div>
 
 
+        <div class="row row-padded">
+            <div class="col-12">
+                <div class="card">
+                    <h5 class="card-header">
+                        BrewStatus Settings
+                    </h5>
+                    <div class="card-body">
+                        <p class="card-text">These settings control how TiltBridge talks to
+                            <a href="https://www.brewstat.us/">BrewStatus</a>. To disable pushing to BrewStatus, delete
+                            the BrewStatus URL.
+                        </p>
+                        <form action="/settings/update/" method="POST">
+                            <div class="form-group row">
+                                <label for="brewstatusURL" class="col-sm-2 col-form-label" data-toggle="tooltip" title="Target BrewStatus tiltbridge URL. Delete to disable pushing to BrewStatus">BrewStatus URL</label>
+                                <div class="col-sm-8">
+                                    <input type="text" class="form-control" name="brewstatusURL" id="brewstatusURL" placeholder="https://www.brewstat.us/tilt/xxxxxxxxxx/log" :value="settings.brewstatusURL">
+                                </div>
+                                <div class="col-sm-2"><button type="submit" class="btn btn-primary">Update</button></div>
+                            </div>
+                        </form>
+
+                        <form action="/settings/update/" method="POST">
+                            <div class="form-group row">
+                                <label for="brewstatusPushEvery" class="col-sm-2 col-form-label" data-toggle="tooltip" title="How often (in seconds) to push data to Brewstatus">Push Frequency</label>
+                                <div class="col-sm-8">
+                                    <input type="text" class="form-control" name="brewstatusPushEvery" id="brewstatusPushEvery" placeholder="30" :value="settings.brewstatusPushEvery">
+                                </div>
+                                <div class="col-sm-2"><button type="submit" class="btn btn-primary">Update</button></div>
+                            </div>
+                        </form>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </div>
 
 

--- a/src/SecureWithRedirects.cpp
+++ b/src/SecureWithRedirects.cpp
@@ -14,7 +14,7 @@
 #include <WiFiClientSecure.h>
 
 
-SecureWithRedirects::SecureWithRedirects(const char * original_url, const char *api_key, const char *data_to_send) {
+SecureWithRedirects::SecureWithRedirects(const char * original_url, const char *api_key, const char *data_to_send, const char *content_type) {
     // Initialize secure_client & HTTPClient
     secure_client = new WiFiClientSecure;
     https = new HTTPClient;
@@ -31,6 +31,7 @@ SecureWithRedirects::SecureWithRedirects(const char * original_url, const char *
     url = original_url;
     apiKey=api_key;
     dataToSend=data_to_send;
+    contentType=content_type;
 }
 
 
@@ -64,7 +65,7 @@ bool SecureWithRedirects::send_with_redirects() {
     Serial.println("`");
 
     https->begin(*secure_client, url);
-    https->addHeader("Content-Type", "application/json");             //Specify content-type header
+    https->addHeader("Content-Type", contentType);             //Specify content-type header
     if (apiKey) {
         https->addHeader("X-API-KEY", apiKey);  //Specify API key header
     }

--- a/src/SecureWithRedirects.h
+++ b/src/SecureWithRedirects.h
@@ -13,7 +13,7 @@
 class SecureWithRedirects {
 
 public:
-    SecureWithRedirects(const char * original_url, const char *api_key, const char *data_to_send);
+    SecureWithRedirects(const char * original_url, const char *api_key, const char *data_to_send, const char *content_type);
     void end();
     bool send_with_redirects();
 
@@ -26,6 +26,7 @@ private:
     String url;
     const char *apiKey;
     const char *dataToSend;
+    const char *contentType;
 
 };
 

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -170,7 +170,6 @@ void processConfig() {
             return processConfigError();
         else if (server.arg("brewstatusTZoffset").length() <= 0)
             return processConfigError();
-        }
 
         float tzoffset = strtof(server.arg("brewstatusTZoffset").c_str(), nullptr);
         if(tzoffset < -12.0) {

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -164,6 +164,26 @@ void processConfig() {
         Serial.println("Updated brewstatusPushEvery");
     }
 
+    if (server.hasArg("brewstatusTZoffset")) {
+        Serial.println("Has brewstatusTZoffset");
+        if (server.arg("brewstatusTZoffset").length() > 3)
+            return processConfigError();
+        else if (server.arg("brewstatusTZoffset").length() <= 0)
+            return processConfigError();
+        }
+
+        float tzoffset = strtof(server.arg("brewstatusTZoffset").c_str(), nullptr, 10);
+        if(tzoffset < -12.0) {
+            Serial.println("brewstatusTZoffset is less than -12!");
+            return processConfigError();
+        } else if(tzoffset > 12.0) {
+            Serial.println("brewstatusTZoffset is greater than 12!");
+            return processConfigError();
+        else
+            app_config.config["brewstatusTZoffset"] = tzoffset;
+        Serial.println("Updated brewstatusTZoffset");
+    }
+
     // Google Sheets Settings
     if (server.hasArg("scriptsURL")) {
         // TODO - Validate this begins with "https://scripts.google.com/"

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -172,15 +172,16 @@ void processConfig() {
             return processConfigError();
         }
 
-        float tzoffset = strtof(server.arg("brewstatusTZoffset").c_str(), nullptr, 10);
+        float tzoffset = strtof(server.arg("brewstatusTZoffset").c_str(), nullptr);
         if(tzoffset < -12.0) {
             Serial.println("brewstatusTZoffset is less than -12!");
             return processConfigError();
         } else if(tzoffset > 12.0) {
             Serial.println("brewstatusTZoffset is greater than 12!");
             return processConfigError();
-        else
+        } else {
             app_config.config["brewstatusTZoffset"] = tzoffset;
+        }
         Serial.println("Updated brewstatusTZoffset");
     }
 

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -130,6 +130,39 @@ void processConfig() {
         Serial.println("Updated fermentrackPushEvery");
     }
 
+    // Brewstatus Settings
+    if (server.hasArg("brewstatusURL")) {
+        // TODO - Add a check here to make sure that brewstatusURL actually changed, and return if it didn't
+        if (server.arg("brewstatusURL").length() > 255)
+            return processConfigError();
+        else if (server.arg("brewstatusURL").length() < 12)
+            app_config.config["brewstatusURL"] = "";
+        else
+            app_config.config["brewstatusURL"] = server.arg("brewstatusURL").c_str();
+    }
+
+    if (server.hasArg("brewstatusPushEvery")) {
+        Serial.println("Has brewstatusPushEvery");
+        if (server.arg("brewstatusPushEvery").length() > 5)
+            return processConfigError();
+        else if (server.arg("brewstatusPushEvery").length() <= 0)
+            return processConfigError();
+        else if (!isInteger(server.arg("brewstatusPushEvery").c_str())) {
+            Serial.println("brewstatusPushEvery is not an integer!");
+            return processConfigError();
+        }
+
+        // At this point, we know that it's an integer. Let's convert to a long so we can test the value
+        // TODO - Figure out if we want to print error messages for these
+        long push_every = strtol(server.arg("brewstatusPushEvery").c_str(), nullptr, 10);
+        if(push_every < 30)
+            app_config.config["brewstatusPushEvery"] = 30;
+        else if(push_every > 60*60)
+            app_config.config["brewstatusPushEvery"] = 60*60;
+        else
+            app_config.config["brewstatusPushEvery"] = push_every;
+        Serial.println("Updated brewstatusPushEvery");
+    }
 
     // Google Sheets Settings
     if (server.hasArg("scriptsURL")) {

--- a/src/jsonConfigHandler.cpp
+++ b/src/jsonConfigHandler.cpp
@@ -28,6 +28,10 @@ void jsonConfigHandler::initialize() {
             {"fermentrackURL", ""},
             {"fermentrackPushEvery", 30},
 
+            // Brewstatus Settings
+            {"brewstatusURL", ""},
+            {"brewstatusPushEvery", 60},
+
             // Google Scripts Settings
             {"scriptsURL", ""},
             {"scriptsEmail", ""},

--- a/src/jsonConfigHandler.cpp
+++ b/src/jsonConfigHandler.cpp
@@ -31,6 +31,7 @@ void jsonConfigHandler::initialize() {
             // Brewstatus Settings
             {"brewstatusURL", ""},
             {"brewstatusPushEvery", 60},
+            {"brewstatusTZoffset", -5},
 
             // Google Scripts Settings
             {"scriptsURL", ""},

--- a/src/sendData.cpp
+++ b/src/sendData.cpp
@@ -99,6 +99,7 @@ bool dataSendHandler::send_to_brewstatus() {
     // The Timepoint is Google Sheets time, which is fractional days since 12/30/1899
     // Using https://www.timeanddate.com/date/durationresult.html?m1=12&d1=30&y1=1899&m2=1&d2=1&y2=1970 gives
     // us 25,569 days from the start of Google Sheets time to the start of the Unix epoch.
+    // BrewStatus wants local time, so we allow the user to specify a time offset.
 
     // Loop through each of the tilt colors cached by tilt_scanner, sending data for each of the active tilts
     for(uint8_t i = 0;i<TILT_COLORS;i++) {
@@ -107,8 +108,8 @@ bool dataSendHandler::send_to_brewstatus() {
                      (float) tilt_scanner.tilt(i)->gravity / 1000,
                      (float) tilt_scanner.tilt(i)->temp,
                      tilt_scanner.tilt(i)->color_name().c_str(),
-                     ((double) std::time(0) / 86400.0 + 25569.0) + (app_config.config["brewstatusTZoffset"].get<double>() * 3600.0)
-                    );
+                     ((double) std::time(0) + (app_config.config["brewstatusTZoffset"].get<double>() * 3600.0))
+                     / 86400.0 + 25569.0);
             if(!send_to_url(app_config.config["brewstatusURL"].get<std::string>().c_str(), "", payload, "application/x-www-form-urlencoded"))
                 result = false;  // There was an error with the previous send
         }

--- a/src/sendData.cpp
+++ b/src/sendData.cpp
@@ -107,7 +107,7 @@ bool dataSendHandler::send_to_brewstatus() {
                      (float) tilt_scanner.tilt(i)->gravity / 1000,
                      (float) tilt_scanner.tilt(i)->temp,
                      tilt_scanner.tilt(i)->color_name().c_str(),
-                     (double) std::time(0) / 86400.0 + 25569.0
+                     ((double) std::time(0) / 86400.0 + 25569.0) + (app_config.config["brewstatusTZoffset"].get<double>() * 3600.0)
                     );
             if(!send_to_url(app_config.config["brewstatusURL"].get<std::string>().c_str(), "", payload, "application/x-www-form-urlencoded"))
                 result = false;  // There was an error with the previous send

--- a/src/sendData.h
+++ b/src/sendData.h
@@ -24,6 +24,7 @@
 #define BREWFATHER_MIN_KEY_LENGTH       5
 #define BREWERS_FRIEND_MIN_KEY_LENGTH   12
 #define FERMENTRACK_MIN_URL_LENGTH      12
+#define BREWSTATUS_MIN_URL_LENGTH       12
 #define GSCRIPTS_MIN_URL_LENGTH         24
 #define GSCRIPTS_MIN_EMAIL_LENGTH       7
 
@@ -45,6 +46,7 @@ public:
 
 private:
     uint64_t send_to_fermentrack_at;
+    uint64_t send_to_brewstatus_at;
     uint64_t send_to_brewers_friend_at;
     uint64_t send_to_google_at;
     uint64_t send_to_brewfather_at;
@@ -57,13 +59,14 @@ private:
 #ifdef USE_SECURE_GSCRIPTS
     // This is necessary for HTTPS support (which is useless until ESP32 bluetooth support is improved)
     void setClock();
-    static bool send_to_url_https(const char *url, const char *apiKey, const char *dataToSend);
+    static bool send_to_url_https(const char *url, const char *apiKey, const char *dataToSend, const char *contentType);
 #endif
 
     bool send_to_fermentrack();
+    bool send_to_brewstatus();
     bool send_to_google();
 
-    static bool send_to_url(const char *url, const char *apiKey, const char *dataToSend);
+    static bool send_to_url(const char *url, const char *apiKey, const char *dataToSend, const char* contentType);
     bool send_to_bf_and_bf(uint8_t which_bf);  // Handler for both Brewer's Friend and Brewfather
 
 };


### PR DESCRIPTION
Implement the ability to push to https://brewstat.us/

BrewStatus uses `application/x-www-form-urlencoded` but the `send_to_url()` function was hard wired to use `application/json` so I added an argument to allow the user to set the content type in the headers.