### PR TITLE
Set temp unit correctly in MQTT Payload

### DIFF
--- a/src/sendData.cpp
+++ b/src/sendData.cpp
@@ -395,7 +395,7 @@ bool dataSendHandler::send_to_mqtt() {
             payload["color"] = tilt_scanner.tilt(i)->color_name();
             payload["device"] = app_config.config["mdnsID"].get<std::string>();
             payload["temp"] = tilt_scanner.tilt(i)->converted_temp().c_str();
-            payload["temp_unit"] = "F";
+            payload["temp_unit"] = app_config.config["tempUnit"].get<std::string>();
 
             payload["gravity"] = tilt_scanner.tilt(i)->converted_gravity().c_str();
             payload["gravity_unit"] = "G";

--- a/src/tilt/tiltHydrometer.h
+++ b/src/tilt/tiltHydrometer.h
@@ -55,6 +55,7 @@ public:
     uint16_t temp;
     uint16_t gravity;
     uint16_t version_code;
+    uint32_t filter_accumulator;
 
     uint8_t weeks_since_last_battery_change;
 


### PR DESCRIPTION
Update to correctly set temperature unit designation in the MQTT payload.