### PR TITLE
Add setting for configuring amount of specific gravity smoothing.

### DIFF
--- a/data/settings.htm
+++ b/data/settings.htm
@@ -65,9 +65,27 @@
                         <p class="card-text">These settings apply to the TiltBridge as a whole. Updating mDNS will cause the TiltBridge to restart.</p>
                         <form action="/settings/update/" method="POST" enctype="multipart/form-data">
                             <div class="form-group row">
-                                <label for="mdnsID" class="col-sm-2 col-form-label" data-toggle="tooltip" title="mDNS name (the xxxx in http://xxxx.local/)">mDNS ID</label>
+                                <label for="mdnsID" class="col-sm-3 col-form-label" data-toggle="tooltip" title="mDNS name (the xxxx in http://xxxx.local/)">mDNS ID</label>
                                 <div class="col-sm-8">
                                     <input type="text" class="form-control" name="mdnsID" id="mdnsID" placeholder="tiltbridge" :value="settings.mdnsID">
+                                </div>
+                            </div>
+                            <div class="form-group row">
+                                <label for="tempUnit" class="col-sm-3 col-form-label" data-toggle="tooltip" title="Units used for temperature measurement">Temperature Units</label>
+                                <div class="col-sm-8">
+                                    <select class="form-control" name="tempUnit" id="tempUnit">
+                                        <option value="C" selected>Celsius (&deg;C)</option>
+                                        <option value="F">Fahrenheit (&deg;F)</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="form-group row">
+                                <label for="smoothFactor" class="col-sm-3 col-form-label" data-toggle="tooltip" title="Valid range 0 to 99. Setting affects time constant of
+                                exponentially weighted moving average filter applied to specific gravity reading. 
+                                A value of 0 is equivalent to no averaging. Higher values mean more averaging.
+                                A value of 40 gives time constant of just over 5 seconds while a value of 99 results in over 8 minutes.">Specific Gravity Averaging</label>
+                                <div class="col-sm-8">
+                                    <input type="text" class="form-control" name="smoothFactor" id="smoothFactor" placeholder="40" :value="settings.smoothFactor">
                                 </div>
                             </div>
                             <div class="form-group row">
@@ -119,34 +137,6 @@
                             </div>
                             <div class="form-group row">
                                 <div class="col-sm-5"></div>
-                                <div class="col-sm-2"><button type="submit" class="btn btn-primary">Update</button></div>
-                            </div>
-                        </form>
-                    </div>
-                </div>
-
-            </div>
-        </div>
-
-        <!-- TODO - COme back and integrate temp units with Pletch's changes -->
-        <div class="row row-padded">
-            <div class="col-12">
-                <div class="card">
-                    <h5 class="card-header">
-                        Units
-                    </h5>
-
-                    <div class="card-body">
-                        <p class="card-text">These settings control whether to use fahrenheit or celsius.</p>
-                        <form action="/settings/update/" method="POST">
-                            <div class="form-group row">
-                                <label for="tempUnit" class="col-sm-2 col-form-label" data-toggle="tooltip" title="Units used for temperature measurement">Temperature in</label>
-                                <div class="col-sm-8">
-                                    <select class="form-control" name="tempUnit" id="tempUnit">
-                                        <option value="C" selected>Celsius (&deg;C)</option>
-                                        <option value="F">Fahrenheit (&deg;F)</option>
-                                    </select>
-                                </div>
                                 <div class="col-sm-2"><button type="submit" class="btn btn-primary">Update</button></div>
                             </div>
                         </form>

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -143,6 +143,17 @@ void processConfig() {
         }
     }
 
+    if (server.hasArg("smoothFactor")) {
+        int smooth_factor;
+        bool is_int;
+        isInteger(server.arg("smoothFactor").c_str(),is_int,smooth_factor);
+        if (is_int && smooth_factor >= 0 && smooth_factor <= 99) {
+            app_config.config["smoothFactor"] = smooth_factor;
+        } else {
+            all_settings_valid = false;
+        }
+    }
+
     if (server.hasArg("invertTFT")) {
         if((server.arg("invertTFT")=="on") && (!app_config.config["invertTFT"].get<bool>())) {
             app_config.config["invertTFT"] = true;

--- a/src/jsonConfigHandler.cpp
+++ b/src/jsonConfigHandler.cpp
@@ -25,6 +25,8 @@ void jsonConfigHandler::initialize() {
             {"mdnsID", "tiltbridge"},
             {"invertTFT", false},
             {"update_spiffs", false},
+            {"tempUnit", "F"},
+            {"smoothFactor",40},
 
             // Global Calibration settings
             {"applyCalibration", false},
@@ -38,10 +40,7 @@ void jsonConfigHandler::initialize() {
             {"cal_orange", { {"degree", 1}, {"x0", 0.0}, {"x1", 1.0}, {"x2", 0.0}, {"x3", 0.0}}},
             {"cal_blue", { {"degree", 1}, {"x0", 0.0}, {"x1", 1.0}, {"x2", 0.0}, {"x3", 0.0}}},
             {"cal_yellow", { {"degree", 1}, {"x0", 0.0}, {"x1", 1.0}, {"x2", 0.0}, {"x3", 0.0}}},
-            {"cal_pink", { {"degree", 1}, {"x0", 0.0}, {"x1", 1.0}, {"x2", 0.0}, {"x3", 0.0}}},
-
-            // Default units
-            {"tempUnit", "F"},
+            {"cal_pink", { {"degree", 1}, {"x0", 0.0}, {"x1", 1.0}, {"x2", 0.0}, {"x3", 0.0}}},            
 
             // Fermentrack Settings
             {"fermentrackURL", ""},

--- a/src/tilt/tiltHydrometer.h
+++ b/src/tilt/tiltHydrometer.h
@@ -56,7 +56,7 @@ public:
     uint16_t gravity;
     uint16_t gravity_smoothed;
     uint16_t version_code;
-    uint32_t filter_accumulator;
+    uint16_t last_grav_value;
 
     uint8_t weeks_since_last_battery_change;
 


### PR DESCRIPTION
Smoothing factor affects time constant of the smoothing filter for specific gravity.  User can turn off smoothing entirely by setting value to 0.  Default value of 40 should give time constant of around 5 seconds if Tilt is providing reading to Tiltbridge every 5 seconds.
  
Also moved Temperature unit selection up under General Tiltbridge settings.