### PR TITLE
Provide alert box if setting is invalid, set DHCP name correctly, add general timezone offset for use with google sheets.

### DIFF
--- a/data/settings.htm
+++ b/data/settings.htm
@@ -71,6 +71,12 @@
                                 </div>
                             </div>
                             <div class="form-group row">
+                                <label for="TZoffset" class="col-sm-3 col-form-label" data-toggle="tooltip" title="Time zone offset from GMT (in hours)">Time Zone Offset</label>
+                                <div class="col-sm-8">
+                                    <input type="text" class="form-control" name="TZoffset" id="TZoffset" placeholder="-5" :value="settings.TZoffset">
+                                </div>
+                            </div>
+                            <div class="form-group row">
                                 <label for="tempUnit" class="col-sm-3 col-form-label" data-toggle="tooltip" title="Units used for temperature measurement">Temperature Units</label>
                                 <div class="col-sm-8">
                                     <select class="form-control" name="tempUnit" id="tempUnit">
@@ -353,13 +359,6 @@
                                 <label for="brewstatusPushEvery" class="col-sm-3 col-form-label" data-toggle="tooltip" title="How often to push data to BrewStatus (Range: 30 - 3600 seconds)">Push Frequency (s)</label>
                                 <div class="col-sm-8">
                                     <input type="text" class="form-control" name="brewstatusPushEvery" id="brewstatusPushEvery" placeholder="30" :value="settings.brewstatusPushEvery">
-                                </div>
-                            </div>
-
-                            <div class="form-group row">
-                                <label for="brewstatusTZoffset" class="col-sm-3 col-form-label" data-toggle="tooltip" title="Time zone offset from UTC (in hours)">Time Zone Offset</label>
-                                <div class="col-sm-8">
-                                    <input type="text" class="form-control" name="brewstatusTZoffset" id="brewstatusTZoffset" placeholder="-5" :value="settings.brewstatusTZoffset">
                                 </div>
                             </div>
                             <div class="form-group row">

--- a/data/settings.htm
+++ b/data/settings.htm
@@ -81,11 +81,11 @@
                             </div>
                             <div class="form-group row">
                                 <label for="smoothFactor" class="col-sm-3 col-form-label" data-toggle="tooltip" title="Valid range 0 to 99. Setting affects time constant of
-                                exponentially weighted moving average filter applied to specific gravity reading. 
-                                A value of 0 is equivalent to no averaging. Higher values mean more averaging.
-                                A value of 40 gives time constant of just over 5 seconds while a value of 99 results in over 8 minutes.">Specific Gravity Averaging</label>
+                                exponentially weighted moving average filter applied to specific gravity reading. In response to a step change, the filtered value should 
+                                reach steady state after ~ 5 time constants. Setting of 0 is equivalent to no averaging (filtering off) while higher values mean more averaging.
+                                Setting of 60 gives time constant of just over 5 seconds while 99 results in ~ 5 minutes.">Specific Gravity Averaging</label>
                                 <div class="col-sm-8">
-                                    <input type="text" class="form-control" name="smoothFactor" id="smoothFactor" placeholder="40" :value="settings.smoothFactor">
+                                    <input type="text" class="form-control" name="smoothFactor" id="smoothFactor" placeholder="60" :value="settings.smoothFactor">
                                 </div>
                             </div>
                             <div class="form-group row">

--- a/data/settings.htm
+++ b/data/settings.htm
@@ -473,6 +473,7 @@
                 xhr.open('GET', '/settings/json/');
                 xhr.onload = function () {
                     self.settings = JSON.parse(xhr.responseText);
+                    if ( self.settings.all_valid == "0" ) window.alert("Invalid value for one or more parameters!  Please confirm settings and resubmit");
                     if ( self.settings.invertTFT ) document.getElementById("invertTFT").checked = true;
                     if ( self.settings.applyCalibration ) document.getElementById("applyCalibration").checked = true;
                     if ( self.settings.tempCorrect ) document.getElementById("tempCorrect").checked = true;

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -146,6 +146,22 @@ void processConfig() {
         }
     }
 
+    if (server.hasArg("TZoffset")) {
+        if (server.arg("TZoffset").length() > 0 && server.arg("TZoffset").length() <= 3 ) {
+            int tzo;
+            bool is_int;
+            isInteger(server.arg("TZoffset").c_str(),is_int,tzo);
+            if(tzo >= -11 && tzo <= 12) {
+                app_config.config["TZoffset"] = tzo;
+            } else {
+#ifdef DEBUG_PRINTS
+                Serial.println(F("brewstatusTZoffset is not between -11 and 12!"));
+#endif
+                all_settings_valid = false;
+            }
+        }
+    }
+
     if (server.hasArg("smoothFactor")) {
         int sf;
         bool is_int;
@@ -239,20 +255,6 @@ void processConfig() {
             app_config.config["brewstatusPushEvery"] = push_every;
         } else {
             all_settings_valid = false;
-        }
-    }
-
-    if (server.hasArg("brewstatusTZoffset")) {
-        if (server.arg("brewstatusTZoffset").length() > 0 && server.arg("brewstatusTZoffset").length() <= 3 ) {
-            float tzoffset = strtof(server.arg("brewstatusTZoffset").c_str(), nullptr);
-            if(tzoffset >= -12.0 && tzoffset <= 12.0) {
-                app_config.config["brewstatusTZoffset"] = tzoffset;
-            } else {
-#ifdef DEBUG_PRINTS
-                Serial.println(F("brewstatusTZoffset is not between -12 and 12!"));
-#endif
-                all_settings_valid = false;
-            }
         }
     }
 

--- a/src/jsonConfigHandler.cpp
+++ b/src/jsonConfigHandler.cpp
@@ -25,6 +25,7 @@ void jsonConfigHandler::initialize() {
             {"mdnsID", "tiltbridge"},
             {"invertTFT", false},
             {"update_spiffs", false},
+            {"TZoffset", -5},
             {"tempUnit", "F"},
             {"smoothFactor",60},
 
@@ -49,7 +50,6 @@ void jsonConfigHandler::initialize() {
             // Brewstatus Settings
             {"brewstatusURL", ""},
             {"brewstatusPushEvery", 60},
-            {"brewstatusTZoffset", -5},
 
             // Google Scripts Settings
             {"scriptsURL", ""},

--- a/src/jsonConfigHandler.cpp
+++ b/src/jsonConfigHandler.cpp
@@ -26,7 +26,7 @@ void jsonConfigHandler::initialize() {
             {"invertTFT", false},
             {"update_spiffs", false},
             {"tempUnit", "F"},
-            {"smoothFactor",40},
+            {"smoothFactor",60},
 
             // Global Calibration settings
             {"applyCalibration", false},

--- a/src/sendData.cpp
+++ b/src/sendData.cpp
@@ -135,7 +135,7 @@ bool dataSendHandler::send_to_brewstatus() {
                      tilt_scanner.tilt(i)->converted_gravity(false).c_str(),
                      tilt_scanner.tilt(i)->converted_temp(true).c_str(),  // Only sending Fahrenheit numbers since we don't send units
                      tilt_scanner.tilt(i)->color_name().c_str(),
-                     ((double) std::time(0) + (app_config.config["brewstatusTZoffset"].get<double>() * 3600.0))
+                     ((double) std::time(0) + (app_config.config["TZoffset"].get<int8_t>() * 3600.0))
                      / 86400.0 + 25569.0);
             if(!send_to_url(app_config.config["brewstatusURL"].get<std::string>().c_str(), "", payload, "application/x-www-form-urlencoded"))
                 result = false;  // There was an error with the previous send
@@ -230,6 +230,7 @@ bool dataSendHandler::send_to_google() {
             payload["Color"] = tilt_scanner.tilt(i)->color_name();
             payload["Comment"] = "";
             payload["Email"] = app_config.config["scriptsEmail"].get<std::string>(); // The gmail email address associated with the script on google
+            payload["tzOffset"] = app_config.config["TZoffset"].get<int8_t>();
 
             // When sending the data to GScripts directly, we're sending the payload - not the wrapped payload
             if(!send_to_url_https(app_config.config["scriptsURL"].get<std::string>().c_str(), "", payload.dump().c_str(), "application/json"))

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -111,12 +111,6 @@ void init_wifi() {
         app_config.save();
     }
 
-//    WiFi.mode(WIFI_STA);
-//    WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
-//    WiFi.setHostname(mdns_id.c_str());
-//    WiFi.begin();
-//    delay(500);
-
     if (!MDNS.begin(mdns_id.c_str())) {
 //        Serial.println("Error setting up MDNS responder!");
     }
@@ -136,6 +130,12 @@ void init_wifi() {
     strcat(ip_address_url,"/");
 
     lcd.display_wifi_success_screen(mdns_url, ip_address_url);
+    // In order to have the system register the mDNS name in DHCP table, it is necessary to flush config
+    // and reinitialize Wifi connection. If this is not done, the DHCP hostname is always just registered 
+    // as espressif.  See: https://github.com/espressif/arduino-esp32/issues/2537
+    WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+    WiFi.setHostname(mdns_id.c_str());
+    WiFi.begin();
     delay(1000);
 }
 


### PR DESCRIPTION
It bothered me that the settings page just returns silently if an invalid setting is input.  I added some code to append an all_valid flag to the end of the json string when it is requested by the http client.  This way, the javascript can pop up an alert box if one of the settings was found to be invalid by the process_config function.  There is probably a better way to do this but this is the first approach I could come up with without more research into options.

