### PR TITLE
Tweaks

### DIFF
--- a/data/about.htm
+++ b/data/about.htm
@@ -9,9 +9,9 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
-
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    
     <style>
         body {padding-top: 5rem; padding-bottom: 5rem;}
 

--- a/data/calibration.htm
+++ b/data/calibration.htm
@@ -9,9 +9,9 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
-
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    
     <style>
         body {padding-top: 5rem; padding-bottom: 5rem;}
 

--- a/data/index.htm
+++ b/data/index.htm
@@ -9,8 +9,8 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
     <!-- Custom styles for this template -->
     <style>
@@ -110,9 +110,12 @@
                 xhr.onload = function () {
                     self.fullDict = JSON.parse(xhr.responseText);
                     self.sensors = [];
-                    Object.keys(self.fullDict).forEach(function(key) {
+                    
+                    if (self.fullDict != null) {
+                        Object.keys(self.fullDict).forEach(function(key) {
                         self.sensors.push(self.fullDict[key]);
-                    });
+                        });
+                    }
                     //console.log(self.fullDict);
                     //console.log(self.sensors);
                 };

--- a/data/restarting.htm
+++ b/data/restarting.htm
@@ -9,10 +9,8 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
-
-    <meta http-equiv="refresh" content="20;url=/" />
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
     <!-- Custom styles for this template -->
     <style>
@@ -59,10 +57,45 @@
 
     <p>
         Your TiltBridge is currently being restarted. You should be automatically redirected to the TiltBridge's main
-        dashboard in 20 seconds or you can <a href="/">click here</a> once the TiltBridge has finished reconnecting.
+        dashboard in 20 seconds or you can <a href="#" onclick="redirect_now()">click here</a> once the TiltBridge has finished reconnecting.
     </p>
 
 </main>
+
+<script>
+    function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    function getmdns(url) {
+        return new Promise(function(resolve) {
+            var xhr = new XMLHttpRequest();
+            xhr.onload = function() {
+                resolve(JSON.parse(xhr.responseText));
+            };
+            xhr.open('GET', url);
+            xhr.overrideMimeType("application/json");         
+            xhr.send();
+        });
+    }
+
+    function redirect_now() {
+        getmdns("/settings/json/")
+            .then(function(result) {
+                window.location.replace("http://" + result.mdnsID + ".local");
+            })
+    }
+
+    async function delayed_redirect() {
+        await sleep(20000);
+        getmdns("/settings/json/")
+            .then(function(result) {
+                window.location.replace("http://" + result.mdnsID + ".local");
+            })
+    }
+
+    delayed_redirect();
+</script>
 
 <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>

--- a/data/restarting.htm
+++ b/data/restarting.htm
@@ -63,11 +63,6 @@
 </main>
 
 <script>
-    function sleep(delay) {
-    var start = new Date().getTime();
-    while (new Date().getTime() < start + delay);
-    }
-
     function asleep(ms) {
         return new Promise(resolve => setTimeout(resolve, ms));
     }

--- a/data/restarting.htm
+++ b/data/restarting.htm
@@ -63,7 +63,12 @@
 </main>
 
 <script>
-    function sleep(ms) {
+    function sleep(delay) {
+    var start = new Date().getTime();
+    while (new Date().getTime() < start + delay);
+    }
+
+    function asleep(ms) {
         return new Promise(resolve => setTimeout(resolve, ms));
     }
 
@@ -79,19 +84,20 @@
         });
     }
 
-    function redirect_now() {
-        getmdns("/settings/json/")
+    var newmDNS;
+    getmdns('/settings/json/')
             .then(function(result) {
-                window.location.replace("http://" + result.mdnsID + ".local");
+                newmDNS = result.mdnsID;
+                //console.log(newmDNS);
             })
+
+    function redirect_now() {
+                window.location.replace("http://" + newmDNS + ".local");
     }
 
     async function delayed_redirect() {
-        await sleep(20000);
-        getmdns("/settings/json/")
-            .then(function(result) {
-                window.location.replace("http://" + result.mdnsID + ".local");
-            })
+        await asleep(20000);
+        window.location.replace("http://" + newmDNS + ".local");
     }
 
     delayed_redirect();

--- a/data/settings.htm
+++ b/data/settings.htm
@@ -9,8 +9,8 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
     <style>
         body {padding-top: 5rem; padding-bottom: 5rem;}

--- a/data/updating.htm
+++ b/data/updating.htm
@@ -9,8 +9,8 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
     <!-- Custom styles for this template -->
     <style>

--- a/data/wifi_reset.htm
+++ b/data/wifi_reset.htm
@@ -9,8 +9,8 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
 
     <!-- Custom styles for this template -->
     <style>

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -579,9 +579,7 @@ void trigger_wifi_reset() {
 
 void trigger_restart() {
     loadFromSpiffs("/restarting.htm");    // Send a message to the user to let them know what is going on
-    delay(1000);                                // Wait 1 second to let everything send
-    tilt_scanner.wait_until_scan_complete();    // Wait for scans to complete (we don't want any tasks running in the background)
-    ESP.restart();         // Restart the TiltBridge
+    http_server.restart_requested = true;
 }
 
 void http_json() {

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -10,6 +10,7 @@ class httpServer {
 public:
     void init();
     void handleClient();
+    bool restart_requested = false;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,8 @@ void loop() {
     data_sender.process();
     lcd.check_screen();
     http_server.handleClient();
-    if (http_server.restart_requested){ // Need to let the main loop cycle to ensure that the mDNS name can be grabbed from /settings/json/ if before restart.
+    if (http_server.restart_requested){ // Restart handling put in main loop to ensure that client has opportunity 
+                                        // to grab the new mDNS name from /settings/json/ before restart for proper redirect.
         if(restart_time <= xTaskGetTickCount()) {
             tilt_scanner.wait_until_scan_complete();    // Wait for scans to complete (we don't want any tasks running in the background)
             ESP.restart();         // Restart the TiltBridge

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ jsonConfigHandler app_config;
 #ifdef DEBUG_PRINTS
 uint64_t trigger_next_data_send = 0;
 #endif
-
+uint64_t restart_time = 0;
 
 #include <driver/i2c.h>
 #include <esp_log.h>
@@ -110,5 +110,13 @@ void loop() {
     data_sender.process();
     lcd.check_screen();
     http_server.handleClient();
+    if (http_server.restart_requested){ // Need to let the main loop cycle to ensure that the mDNS name can be grabbed from /settings/json/ if before restart.
+        if(restart_time <= xTaskGetTickCount()) {
+            tilt_scanner.wait_until_scan_complete();    // Wait for scans to complete (we don't want any tasks running in the background)
+            ESP.restart();         // Restart the TiltBridge
+        }
+    } else {
+        restart_time = xTaskGetTickCount() + 5000;
+    }
     yield();
 }


### PR DESCRIPTION
Address #53 with new JS restart routine leveraging an asyncronous wait after grabbing the updated mDNS name from /settings/json/.

The restart sequence needed to be moved to be initiated from the main loop in order to assure that the updated settings were served to the http client before restarting.