### PR TITLE
Urgent fix to ensure config_updated status is reset

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,6 +111,7 @@ void loop() {
     lcd.check_screen();
     if (http_server.config_updated) {
         app_config.save();
+        http_server.config_updated = false;
     }
     if (http_server.restart_requested){ // Restart handling put in main loop to ensure that client has opportunity 
                                         // to grab the new mDNS name from /settings/json/ before restart for proper redirect.


### PR DESCRIPTION
I neglected to include instruction to reset status of config_updated when I moved it to the main loop.  This should be incorporated quickly becuase it is likely writing to spiffs repeatedly in the main loop after config is updated.  OOPS!!!