### PR TITLE
Monitor_dtr = 1 causing instability with Serial

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@ monitor_speed = 115200
 ; Ths can/will be set in tools/get_port.py
 ; upload_port = 
 ; monitor_port = 
-monitor_dtr = 1
+monitor_dtr = 0
 monitor_rts = 0
 
 ; -D_GLIBCXX_USE_C99 is to fix an issue with the xtensa toolchain that precludes the use of std::to_string


### PR DESCRIPTION
I believe this setting polluted the platformio.ini during one of my commits.  

One of the ESP32 boards I was using would always reboot when attaching monitor and this was an attempt to eliminate.  However, I have actually tracked down some instability with serial connection & debugging to using a setting of 1. I am now using 0 as a default.  Not sure if others have had any weird issues related to this??