### PR TITLE
Adjust BLE scan window and interval

### DIFF
--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -10,7 +10,7 @@ httpServer http_server;
 
 AsyncWebServer server(80);
 
-char all_valid[2] = "1";
+static char all_valid[2] = "1";
 
 //void trigger_restart();
 void trigger_restart(AsyncWebServerRequest *request);

--- a/src/sendData.cpp
+++ b/src/sendData.cpp
@@ -50,7 +50,7 @@ void dataSendHandler::init_mqtt()
 {
     if (strlen(config.mqttBrokerIP) > IP_MIN_STRING_LENGTH)
     {
-        Log.verbose(F("Initializing Connection to MQTTBroker at IP: %s on port: $d" CR), config.mqttBrokerIP, config.mqttBrokerPort);
+        Log.verbose(F("Initializing Connection to MQTTBroker at IP: %s on port: %d" CR), config.mqttBrokerIP, config.mqttBrokerPort);
         mqttClient.setKeepAlive(config.mqttPushEvery * 1000);
 
         if (mqtt_alreadyinit)
@@ -427,7 +427,6 @@ bool dataSendHandler::send_to_mqtt()
                 {
                     Log.verbose(F("MQTT disconnected. Attempting to reconnect to MQTT Broker" CR));
                     connect_mqtt();
-                    delay(500);
                 }
 
                 result = mqttClient.publish(m_topic, payload_string, retain, 0);

--- a/src/tilt/tiltScanner.cpp
+++ b/src/tilt/tiltScanner.cpp
@@ -60,8 +60,8 @@ void tiltScanner::init()
     //Active scan actively queries devices for more info following detection.
     //
     pBLEScan->setActiveScan(false);
-    pBLEScan->setInterval(115);
-    pBLEScan->setWindow(99); // less or equal setInterval value
+    pBLEScan->setInterval(53);  //Select prime numbers to reduce risk of frequency beat pattern with ibeacon advertisement interval
+    pBLEScan->setWindow(37); // Set to less or equal setInterval value. Leave reasonable gap to allow WiFi some time.
 }
 
 void tiltScanner::deinit()


### PR DESCRIPTION
I think we should proportion a little more time to the Wifi radio so the Window and Interval were adjusted.  I selected prime numbers for both to hopefully reduce risk of developing a beat frequency between the advertising interval of a Tilt and the scan interval time.  Please test and let me know if the settings create any issues with actually discovering and receiving regular updates from a physical Tilt device.  I have been using my emulator with two different ESP32 devices each using a 750 ms sleep and a 50 ms duration for which advertising is on.  I am unsure what the actual Tilt uses but Thorrak mentioned the Tilts send out advertisements about every 800 ms.