### PR TITLE
Simplify tiltScanner::scan.

### DIFF
--- a/src/tilt/tiltScanner.cpp
+++ b/src/tilt/tiltScanner.cpp
@@ -29,11 +29,6 @@ void MyAdvertisedDeviceCallbacks::onResult(NimBLEAdvertisedDevice *advertisedDev
     }
 }
 
-static void ble_scan_complete(NimBLEScanResults scanResults)
-{
-    // Todo - Decide if it makes sense to process scan results here rather than on a callback
-    tilt_scanner.set_scan_active_flag(false);
-}
 
 ////////////////////////////
 // tiltScanner Implementation
@@ -42,7 +37,6 @@ static void ble_scan_complete(NimBLEScanResults scanResults)
 tiltScanner::tiltScanner()
 {
     // Initialize by setting "m_scan_active" false
-    m_scan_active = false;
     for (uint8_t i = 0; i < TILT_COLORS; i++)
         m_tilt_devices[i] = new tiltHydrometer(i);
 
@@ -72,34 +66,20 @@ void tiltScanner::deinit()
     // NimBLEDevice::deinit();  // Deinitialize the scanner & release memory
 }
 
-void tiltScanner::set_scan_active_flag(bool value)
-{
-    m_scan_active = value;
-}
-
 bool tiltScanner::scan()
 {
-    // Set a flag when we start asynchronously scanning to prevent multiple scans from being launched
-    if (!m_scan_active)
+    if (!pBLEScan->isScanning())  // Check if scan already in progress
+    //Try to start a new scan
     {
-        pBLEScan->clearResults(); // delete results from BLEScan buffer to release memory
-
-        if (!pBLEScan->start(BLE_SCAN_TIME, ble_scan_complete, true))
+        pBLEScan->clearResults();   
+        if (pBLEScan->start(BLE_SCAN_TIME, nullptr, true))  //This no longer ever returns true...possibly a bug?? 
         {
-            // We failed to start a scan. There is a race condition where ble_scan_complete gets triggered prior to
-            // the semaphores being released - if we happen to catch things just right, we can end up in an inconsistent
-            // state.
-            Log.verbose(F("Scan already in progress - explicitly stopping." CR));
-
-            pBLEScan->stop();
-            delay(100);
-            return false;
+            return true;  //Scan successfully started.
         }
         else
         {
-            // We successfully started a scan
-            m_scan_active = true;
-            return true;
+            Log.verbose(F("Scan failed to start." CR));
+            return false;  //Scan failed to start.
         }
     }
     return false;
@@ -107,10 +87,10 @@ bool tiltScanner::scan()
 
 bool tiltScanner::wait_until_scan_complete()
 {
-    if (!m_scan_active)
+    if (!pBLEScan->isScanning())
         return false; // Return false if there wasn't a scan active when this was called
 
-    while (m_scan_active)
+    while (pBLEScan->isScanning())
         delay(100); // Otherwise, keep sleeping 100ms at a time until the scan completes
 
     // pBLEScan->stop();

--- a/src/tilt/tiltScanner.h
+++ b/src/tilt/tiltScanner.h
@@ -32,14 +32,12 @@ public:
     bool scan();
 
     bool wait_until_scan_complete();
-    void set_scan_active_flag(bool value);
     uint8_t load_tilt_from_advert_hex(const std::string &advert_string_hex);
     void tilt_to_json_string(char *json_string, bool use_raw_gravity);
 
     tiltHydrometer *tilt(uint8_t color);
 
 private:
-    bool m_scan_active;
     tiltHydrometer *m_tilt_devices[TILT_COLORS]{};
     MyAdvertisedDeviceCallbacks *callbacks;
 };


### PR DESCRIPTION
Nimble provides a library boolean which indicates if a scan is in
  progress eliminating the need for m_scan_active flag.
The race condition issue mentioned in code comments has also been
  addressed through recent Nimble commits removing need to explicitly
  stop scan.
Simplified the code and removed the callback function that is not
  currently used other than to set the removed m_scan_active flag.