### PR TITLE
Set char buffer sizes to json string length

### DIFF
--- a/Json Models/Tilt JSON.md
+++ b/Json Models/Tilt JSON.md
@@ -101,6 +101,12 @@
 }
 ```
 
+## Condensed Tilt JSON 
+
+```
+{"Purple":{"color":"Purple","temp":"64.9","tempUnit":"F","gravity":"1.0093","gsheets_name":"xxxxxxxxxxxxxxxxxxxxxxxxx","weeks_on_battery":10,"sends_battery":true,"high_resolution":true,"fwVersion":0,"rssi":-52},"Orange":{"color":"Orange","temp":"66.0","tempUnit":"F","gravity":"1.0460","gsheets_name":"xxxxxxxxxxxxxxxxxxxxxxxxx","weeks_on_battery":25,"sends_battery":true,"high_resolution":false,"fwVersion":0,"rssi":-68},"Black":{"color":"Black","temp":"64.9","tempUnit":"F","gravity":"1.0093","gsheets_name":"xxxxxxxxxxxxxxxxxxxxxxxxx","weeks_on_battery":10,"sends_battery":true,"high_resolution":true,"fwVersion":0,"rssi":-52},"Blue":{"color":"Blue","temp":"66.0","tempUnit":"F","gravity":"1.0460","gsheets_name":"xxxxxxxxxxxxxxxxxxxxxxxxx","weeks_on_battery":25,"sends_battery":true,"high_resolution":false,"fwVersion":0,"rssi":-68},"Red":{"color":"Red","temp":"64.9","tempUnit":"F","gravity":"1.0093","gsheets_name":"xxxxxxxxxxxxxxxxxxxxxxxxx","weeks_on_battery":10,"sends_battery":true,"high_resolution":true,"fwVersion":0,"rssi":-52},"Yellow":{"color":"Yellow","temp":"66.0","tempUnit":"F","gravity":"1.0460","gsheets_name":"xxxxxxxxxxxxxxxxxxxxxxxxx","weeks_on_battery":25,"sends_battery":true,"high_resolution":false,"fwVersion":0,"rssi":-68},"Pink":{"color":"Pink","temp":"64.9","tempUnit":"F","gravity":"1.0093","gsheets_name":"xxxxxxxxxxxxxxxxxxxxxxxxx","weeks_on_battery":10,"sends_battery":true,"high_resolution":true,"fwVersion":0,"rssi":-52},"Green":{"color":"Green","temp":"66.0","tempUnit":"F","gravity":"1.0460","gsheets_name":"xxxxxxxxxxxxxxxxxxxxxxxxx","weeks_on_battery":25,"sends_battery":true,"high_resolution":false,"fwVersion":0,"rssi":-68}}
+```
+
 ## Serialize:
 
 ```

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -870,7 +870,7 @@ void http_json(AsyncWebServerRequest *request)
 {
      // TODO: JSON Go rework this
     Log.verbose(F("Serving Tilt JSON." CR));
-    char tilt_data[1600];
+    char tilt_data[TILT_ALL_DATA_STRING_SIZE];
     tilt_scanner.tilt_to_json_string(tilt_data, false);
     AsyncWebServerResponse *response = request->beginResponse(200, "application/json", tilt_data);
     request->send(response);

--- a/src/sendData.cpp
+++ b/src/sendData.cpp
@@ -82,7 +82,7 @@ bool dataSendHandler::send_to_localTarget()
 {
     // TODO: (JSON) Come back and tighten this up
     bool result = true;
-    DynamicJsonDocument j(1550);
+    DynamicJsonDocument j(TILT_ALL_DATA_SIZE + 128);
     // This should look like this when sent to Fermentrack:
     // {
     //   'mdns_id': 'mDNS ID Goes Here',
@@ -90,7 +90,7 @@ bool dataSendHandler::send_to_localTarget()
     //            {'color': 'Orange', 'temp': 66, 'gravity': 1.001}
     // }
 
-    char payload[1600];
+    char payload[TILT_ALL_DATA_STRING_SIZE + 128];
 
     j["mdns_id"] = config.mdnsID;
     tilt_scanner.tilt_to_json_string(payload, true);

--- a/src/tilt/tiltHydrometer.h
+++ b/src/tilt/tiltHydrometer.h
@@ -11,6 +11,7 @@
 
 #define TILT_DATA_SIZE 256 // JSON size of a Tilt
 #define TILT_ALL_DATA_SIZE (TILT_DATA_SIZE * TILT_COLORS) // JSON size of 8 Tilts
+#define TILT_ALL_DATA_STRING_SIZE 1696
 
 // There's definitely a better way of doing this
 #define TILT_COLOR_RED 0

--- a/src/tilt/tiltScanner.cpp
+++ b/src/tilt/tiltScanner.cpp
@@ -178,5 +178,5 @@ void tiltScanner::tilt_to_json_string(char *all_tilt_json, bool use_raw_gravity)
             j[color] = serialized(tilt_data);
         }
     }
-    serializeJson(j, all_tilt_json, TILT_ALL_DATA_SIZE);
+    serializeJson(j, all_tilt_json, TILT_ALL_DATA_STRING_SIZE);
 }


### PR DESCRIPTION
The char buffer in the calling functions to tilt_to_json_string should be scaled against the condensed json string size rather than json object size.