### PR TITLE
Remove redundant member variable

### DIFF
--- a/src/tilt/tiltHydrometer.cpp
+++ b/src/tilt/tiltHydrometer.cpp
@@ -17,7 +17,6 @@ tiltHydrometer::tiltHydrometer(uint8_t color)
     weeks_since_last_battery_change = 0; // Not currently implemented - for future use
     tilt_pro = false;
     receives_battery = false;
-    m_has_sent_197 = false;
 
 } // tiltHydrometer
 
@@ -187,14 +186,10 @@ bool tiltHydrometer::set_values(uint16_t i_temp, uint16_t i_grav, uint8_t i_tx_p
         last_grav_value_1000 = smoothed_i_grav_1000;
     }
 
-    if (i_tx_pwr==197)
-        m_has_sent_197 = true;
-    else {
-        if (m_has_sent_197)
-            receives_battery = true;
-        if (receives_battery) 
-            weeks_since_last_battery_change = i_tx_pwr;
-    }
+    if (i_tx_pwr == 197)
+        receives_battery = true;
+    else if (i_tx_pwr != 197 && receives_battery == true)
+        weeks_since_last_battery_change = i_tx_pwr;
 
     Log.verbose(F("DEBUG: %s sends battery: %T, TX_PWR: %d" CR), color_name().c_str(), receives_battery, i_tx_pwr);
 

--- a/src/tilt/tiltHydrometer.h
+++ b/src/tilt/tiltHydrometer.h
@@ -74,7 +74,6 @@ private:
     uint8_t m_color;
     bool m_loaded;           // Has data been loaded from an ad string
     TickType_t m_lastUpdate; // Keep track of when we last updated and stop propagating out stale information
-    bool m_has_sent_197;  // Used to determine if the tilt sends battery life (a 197 tx_pwr followed by a non-197 tx_pwr)
 };
 
 #endif //TILTBRIDGE_TILTHYDROMETER_H


### PR DESCRIPTION
Is there a reason for the extra lines of code and the redundant member variable that will end up with the same value as public class variable receives_battery?