### PR TITLE
Improved Grainfather Support

### DIFF
--- a/data/settings.js
+++ b/data/settings.js
@@ -156,14 +156,14 @@ function populateConfig(callback = null) { // Get configuration settings, popula
                 $('input[name="brewfatherKey"]').val(config.brewfatherKey);
 
                 // Grainfather Tab
-                $('input[name="grainfatherURL_red"]').val(config.grainfatherURL.Red);
-                $('input[name="grainfatherURL_green"]').val(config.grainfatherURL.Green);
-                $('input[name="grainfatherURL_black"]').val(config.grainfatherURL.Black);
-                $('input[name="grainfatherURL_purple"]').val(config.grainfatherURL.Purple);
-                $('input[name="grainfatherURL_orange"]').val(config.grainfatherURL.Orange);
-                $('input[name="grainfatherURL_blue"]').val(config.grainfatherURL.Blue);
-                $('input[name="grainfatherURL_yellow"]').val(config.grainfatherURL.Yellow);
-                $('input[name="grainfatherURL_pink"]').val(config.grainfatherURL.Pink);
+                $('input[name="grainfatherURL_red"]').val(config.Red.grainfatherURL);
+                $('input[name="grainfatherURL_green"]').val(config.Green.grainfatherURL);
+                $('input[name="grainfatherURL_black"]').val(config.Black.grainfatherURL);
+                $('input[name="grainfatherURL_purple"]').val(config.Purple.grainfatherURL);
+                $('input[name="grainfatherURL_orange"]').val(config.Orange.grainfatherURL);
+                $('input[name="grainfatherURL_blue"]').val(config.Blue.grainfatherURL);
+                $('input[name="grainfatherURL_yellow"]').val(config.Yellow.grainfatherURL);
+                $('input[name="grainfatherURL_pink"]').val(config.Pink.grainfatherURL);
 
                 // Brewstatus Tab
                 $('input[name="brewstatusURL"]').val(config.brewstatusURL);

--- a/src/sendData.cpp
+++ b/src/sendData.cpp
@@ -82,8 +82,8 @@ bool dataSendHandler::send_to_localTarget()
         }
         localTargetTicker.once(config.localTargetPushEvery, [](){send_localTarget = true;}); // Set up subsequent send to localTarget
 //        tilt_scanner.init();
+        send_lock = false;
     }
-    send_lock = false;
     return result;
 }
 
@@ -131,8 +131,8 @@ bool send_to_bf_and_bf()
             }
         }
         brewfatherTicker.once(BREWFATHER_DELAY, [](){send_brewfather = true;}); // Set up subsequent send to Brewfather
+        send_lock = false;
     }
-    send_lock = false;
     return retval;
 }
 
@@ -238,8 +238,8 @@ bool dataSendHandler::send_to_grainfather()
             }
         }
         grainfatherTicker.once(GRAINFATHER_DELAY, [](){send_grainfather = true;}); // Set up subsequent send to Grainfather
+        send_lock = false;
     }
-    send_lock = false;
     return result;
 }
 
@@ -290,8 +290,8 @@ bool dataSendHandler::send_to_brewstatus()
             }
         }
         brewStatusTicker.once(config.brewstatusPushEvery, [](){send_brewStatus = true;}); // Set up subsequent send to Brew Status
+        send_lock = false;
     }
-    send_lock = false;
     return result;
 }
 
@@ -427,8 +427,8 @@ bool dataSendHandler::send_to_google()
         gSheetsTicker.once(GSCRIPTS_DELAY, [](){send_gSheets = true;}); // Set up subsequent send to Google Sheets
 
         //tilt_scanner.init();
+        send_lock = false;
     }
-    send_lock = false;
     return result;
 }
 
@@ -743,7 +743,8 @@ bool dataSendHandler::send_to_mqtt()
             }
         }
         mqttTicker.once(config.mqttPushEvery, [](){send_mqtt = true;});   // Set up subsequent send to MQTT
+        send_lock = false;
     }
-    send_lock = false;
+
     return result;
 }

--- a/src/sendData.h
+++ b/src/sendData.h
@@ -61,6 +61,7 @@ public:
 private:
     void connect_mqtt();
     bool send_to_url(const char *url, const char *apiKey, const char *dataToSend, const char *contentType, bool checkBody = false, const char *bodyCheck = "");
+    bool http_send_json(const char *url, const char * payload);
     HTTPClient http;
     WiFiClient client;
     WiFiClient mqClient;


### PR DESCRIPTION
- Add new generic http function for sending json with the standard Httpclient library: Grainfather HTTP response is ``HTTP/2 201``. That does not work with ``strcmp(status +9, "200 OK")`` in ``dataSendHandler::send_to_url``. So I have added a new ``dataSendHandler::http_send_json`` function that uses the  Arduino Httpclient library as it ``dataSendHandler::send_to_google`` already does.
- Fix javascript code for Grainfather settings
- Set the send_lock flag inside the check block: Otherwise it gets overwritten at the end of the function and the next run could cause problems