### PR TITLE
Support M5StickC display

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@
 
 [common]
 platform = espressif32
-platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
+platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#46d5afb17fb91965632dc5fef237117e1fe947fc
 framework = arduino
 ; As the framework has grown, min_spiffs no longer has enough space. We're now
 ; requiring 16MB of flash space for most builds (which comes standard with the
@@ -205,7 +205,9 @@ monitor_dtr = ${common.monitor_dtr}
 monitor_rts = ${common.monitor_rts}
 build_flags =
     ${common.build_flags}
+    -DLCD_TFT_M5STICKC=1
     -DDISABLE_OTA_UPDATES
 lib_deps =
     ${common.lib_deps}
+    m5stack/M5StickC @ 0.2.0
 build_type = ${common.build_type}

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@
 
 [common]
 platform = espressif32
-platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#46d5afb17fb91965632dc5fef237117e1fe947fc
+platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
 framework = arduino
 ; As the framework has grown, min_spiffs no longer has enough space. We're now
 ; requiring 16MB of flash space for most builds (which comes standard with the

--- a/src/bridge_lcd.cpp
+++ b/src/bridge_lcd.cpp
@@ -8,7 +8,7 @@
 
 bridge_lcd lcd;
 
-#if defined(LCD_SSD1306) || defined(LCD_TFT_ESPI)
+#if defined(LCD_SSD1306) || defined(LCD_TFT_ESPI) || defined(LCD_TFT_M5STICKC)
 #include "img/oled_logo.h" // Small logo
 #elif defined LCD_TFT
 #include "img/tft_logo.h" // Large logo
@@ -91,7 +91,16 @@ void bridge_lcd::init() {
 #elif defined(LCD_TFT_ESPI)
     tft = new TFT_eSPI(TFT_WIDTH, TFT_HEIGHT);
     tft->init();
-    tft->fontHeight(TFT_ESPI_FONT_HEIGHT);
+    if (config.invertTFT) {
+        tft->setRotation(1);
+    } else {
+        tft->setRotation(3);
+    }
+    tft->fillScreen(TFT_BLACK);
+
+#elif defined(LCD_TFT_M5STICKC)
+    M5.begin();
+    tft = &M5.Lcd;
     if (config.invertTFT) {
         tft->setRotation(1);
     } else {
@@ -102,7 +111,7 @@ void bridge_lcd::init() {
 }
 
 void bridge_lcd::reinit() {
-#if defined (LCD_TFT) || defined (LCD_TFT_ESPI)
+#if defined (LCD_TFT) || defined (LCD_TFT_ESPI) || defined (LCD_TFT_M5STICKC)
     clear();
     if (config.invertTFT) {
         tft->setRotation(1);
@@ -136,7 +145,7 @@ void bridge_lcd::display_logo(bool fromReset) {
         gimp_image.width,
         gimp_image.height,
         gimp_image.pixel_data);
-#elif defined(LCD_TFT_ESPI)
+#elif defined(LCD_TFT_ESPI) || defined (LCD_TFT_M5STICKC)
     tft->drawXBitmap(
         (tft->width() - oled_logo_width) / 2,
         (tft->height() - oled_logo_height) / 2,
@@ -195,7 +204,7 @@ void bridge_lcd::display_wifi_success_screen(const char *mdns_url, const char *i
     // Displayed at startup when the TiltBridge is configured to connect to WiFi
     clear();
 
-#ifdef LCD_TFT_ESPI
+#if defined(LCD_TFT_ESPI) || defined(LCD_TFT_M5STICKC)
     print_line("Access TiltBridge at:", "", 1);
 #else
     print_line("Access your TiltBridge at:", "", 1);
@@ -214,7 +223,7 @@ void bridge_lcd::display_wifi_reset_screen() {
     clear();
     onResetScreen = true;
 
-#if defined(LCD_SSD1306) || defined(LCD_TFT_ESPI)
+#if defined(LCD_SSD1306) || defined(LCD_TFT_ESPI) || defined(LCD_TFT_M5STICKC)
     print_line("Press the button again to", "", 1);
     print_line("disable autoconnection", "", 2);
     print_line("and start the WiFi ", "", 3);
@@ -246,7 +255,7 @@ void bridge_lcd::display_ota_update_screen()
 
 void bridge_lcd::print_line(const char *left_text, const char *right_text, uint8_t line)
 {
-#ifdef LCD_TFT_ESPI
+#if defined(LCD_TFT_ESPI) || defined(LCD_TFT_M5STICKC)
     print_line("", left_text, right_text, line);
 #else
     print_line(left_text, "", right_text, line);
@@ -299,6 +308,11 @@ void bridge_lcd::print_line(const char *left_text, const char *middle_text, cons
     tft->setFreeFont(FF17);
     tft->drawString(middle_text, 0, starting_pixel_row, GFXFF);
     tft->drawString(right_text, tft->width() / 2, starting_pixel_row, GFXFF);
+#elif defined(LCD_TFT_M5STICKC)
+    int16_t starting_pixel_row = (TFT_M5STICKC_LINE_CLEARANCE + tft->fontHeight(GFXFF)) * (line - 1) + TFT_M5STICKC_LINE_CLEARANCE;
+
+    tft->drawString(middle_text, 0, starting_pixel_row, GFXFF);
+    tft->drawString(right_text, tft->width() / 2, starting_pixel_row, GFXFF);
 #endif
 }
 
@@ -312,7 +326,7 @@ void bridge_lcd::clear() {
 #ifdef LCD_SSD1306
     oled_display->clear();
     oled_display->setFont(SSD1306_FONT);
-#elif defined (LCD_TFT) || defined (LCD_TFT_ESPI)
+#elif defined (LCD_TFT) || defined (LCD_TFT_ESPI) || defined(LCD_TFT_M5STICKC)
     tft->fillScreen(TFT_BLACK);
 #endif
 
@@ -461,7 +475,7 @@ void bridge_lcd::print_tilt_to_line(tiltHydrometer *tilt, uint8_t line) {
     sprintf(gravity, "%s", tilt->converted_gravity(false).c_str());
     sprintf(temp, "%s %s", tilt->converted_temp(false).c_str(), tilt->is_celsius() ? "C" : "F");
 
-#ifdef LCD_TFT_ESPI
+#if defined (LCD_TFT_ESPI) || defined (LCD_TFT_M5STICKC)
     tft->setTextColor(tilt_text_colors[tilt->m_color]);
 #endif
 
@@ -492,7 +506,7 @@ void bridge_lcd::print_tilt_to_line(tiltHydrometer *tilt, uint8_t line) {
             fHeight - 8,
             tilt_text_colors[tilt->m_color]);
     }
-#elif defined(LCD_TFT_ESPI)
+#elif defined(LCD_TFT_ESPI) || defined(LCD_TFT_M5STICKC)
     tft->setTextColor(TFT_WHITE);
 #endif
 }

--- a/src/bridge_lcd.h
+++ b/src/bridge_lcd.h
@@ -37,6 +37,14 @@
 #define GFXFF                   1
 #define TILTS_PER_PAGE          5 // The actual number is one fewer than this - the first row is used for headers
 
+#elif defined(LCD_TFT_M5STICKC)
+
+#include <M5StickC.h>
+
+#define TFT_M5STICKC_LINE_CLEARANCE 0
+#define GFXFF                   2
+#define TILTS_PER_PAGE          5 // The actual number is one fewer than this - the first row is used for headers
+
 #endif // LCD_SSD1306
 
 #ifdef TILTS_PER_PAGE
@@ -83,9 +91,7 @@ private:
 
 #ifdef LCD_SSD1306
     SSD1306Wire *oled_display;
-#elif defined(LCD_TFT)
-    TFT_eSPI *tft;
-#elif defined(LCD_TFT_ESPI)
+#elif defined(LCD_TFT) || defined(LCD_TFT_ESPI) || defined(LCD_TFT_M5STICKC)
     TFT_eSPI *tft;
 #endif // LCD_SSD1306
 


### PR DESCRIPTION
Add support for M5Stick-C display.
Pin espressif/arduino-esp32 version for now, it seems like the arduino core for the ESP32 has been recently updated on github and is now incompatible with our libraries, pin it to before the update for now.