### PR TITLE
Add Github actions workflow to build on PR/push.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: git fetch --prune --unshallow
+
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    # NOTE: Uncomment to enable caching of PlatformIO assets, such as third-party
+    # libraries. Currently, leaving these uncached so that a completely clean build
+    # is performed each time.
+    #
+    # - name: Cache PlatformIO
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: ~/.platformio
+    #     key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+
+    - name: Build all environments
+      run: pio run


### PR DESCRIPTION
Action is based on reference implementation:
  https://docs.platformio.org/en/latest/integration/ci/github-actions.html

The only local change of significance in the action is that we've disabled the
platformio asset caching step, given that we currently have some un-pinned
dependencies. See discussion in https://github.com/thorrak/tiltbridge/pull/185