### PR TITLE
Refactor LCD code and add "Custom User Target"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,85 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - gh_actions
+    tags:
+      - "v*"
+  # pull_request:
+  #   types: [ open, synchronize, edited, reopened, closed ]
+
+jobs:
+  build:
+    name: Build bins for ${{ matrix.pio_env }}
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: true
+      matrix:
+        pio_env: ['lcd_ssd1306', 'd32_pro_tft', 'tft_espi', 'm5stickc_plus']
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3.3.0
+    - run: git fetch --prune --unshallow
+
+    - name: Cache pip
+      uses: actions/cache@v3.2.2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Cache PlatformIO
+      uses: actions/cache@v3.2.2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v4.4.0
+
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+
+    - name: Build all environments
+      run: |
+        pio run -e ${{ matrix.pio_env }}
+        pio run -e ${{ matrix.pio_env }} --target buildfs
+      # sh ./copy_bins.sh
+
+    - name: Copy files
+      run: |
+        cp .pio/build/${{ matrix.pio_env }}/firmware.bin bin/${{ matrix.pio_env }}_firmware.bin
+        cp .pio/build/${{ matrix.pio_env }}/partitions.bin bin/${{ matrix.pio_env }}_partitions.bin
+        cp .pio/build/${{ matrix.pio_env }}/spiffs.bin bin/${{ matrix.pio_env }}_spiffs.bin
+
+
+    # - name: "Create Prerelease"
+    #   uses: "marvinpinto/action-automatic-releases@latest"
+    #   with:
+    #     repo_token: "${{ secrets.GITHUB_TOKEN }}"
+    #     prerelease: true
+    #     files: |
+    #       LICENSE
+    #       bin/*.bin
+
+    - name: Create Draft Release
+      uses: softprops/action-gh-release@v1
+      # if: startsWith(github.ref, 'refs/tags/')
+      with:
+        body: "Draft release"
+        # note you'll typically need to create a personal access token
+        # with permissions to create releases in the other repo
+        token: ${{ secrets.GITHUB_TOKEN }}
+        draft: true
+        prerelease: true
+        files: |
+          LICENSE
+          bin/*.bin
+      env:
+        GITHUB_REPOSITORY: thorrak/tiltbridge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   push:
     branches:
-      - gh_actions
-    tags:
-      - "v*"
+      - master
+    # tags:
+    #   - "v*"
   # pull_request:
   #   types: [ open, synchronize, edited, reopened, closed ]
 
@@ -14,7 +14,7 @@ jobs:
     name: Build bins for ${{ matrix.pio_env }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails
-      fail-fast: true
+      fail-fast: false
       matrix:
         pio_env: ['lcd_ssd1306', 'd32_pro_tft', 'tft_espi', 'm5stickc_plus']
 

--- a/data/settings.htm
+++ b/data/settings.htm
@@ -112,6 +112,7 @@
                             <a class="dropdown-item" data-toggle="tab" href="#brewstatus">Brewstatus</a>
                             <a class="dropdown-item" data-toggle="tab" href="#taplistio">Taplist.io</a>
                             <a class="dropdown-item" data-toggle="tab" href="#mqtt">MQTT</a>
+                            <a class="dropdown-item" data-toggle="tab" href="#usertarget">Generic JSON Target</a>
                         </div>
                     </li>
 
@@ -535,6 +536,36 @@
                         </div>
 
                     </div> <!-- BrewFather Tab -->
+
+                    <div class="tab-pane fade" id="usertarget"> <!-- User Target Tab -->
+
+                        <div class="card-header bg-light border-primary">
+                            <h5 class="card-title">User Target Settings</h5>
+                        </div>
+        
+                        <div class="card-body">
+                            <p class="card-text">
+                                These settings control how TiltBridge talks to a user-defined target. Specify a url
+                                here and TiltBridge will send a 
+                            </p>
+                            <form action="/settings/usertarget/" method="POST">
+                                <div class="form-group row">
+                                    <label for="userTargetURL" class="col-sm-3 col-form-label" data-toggle="tooltip"
+                                        title="URL to send data to">User Target URL</label>
+                                    <div class="col-sm-8">
+                                        <input type="text" class="form-control" name="userTargetURL" id="userTargetURL"
+                                            placeholder="http://www.target.com/" :value="settings.userTargetURL"
+                                            minlength="12" maxlength="128">
+                                    </div>
+                                </div>
+                                <div class="row col-sm-12 justify-content-center">
+                                    <button type="submit" class="btn btn-primary button-update"
+                                    onclick="if(!this.form.checkValidity(this)){return (false);}">Update</button>
+                                </div>
+                            </form>
+                        </div>
+
+                    </div> <!-- User Target Tab -->                    
 
                     <div class="tab-pane fade" id="grainfather"> <!-- Grainfather Tab -->
 

--- a/data/settings.js
+++ b/data/settings.js
@@ -182,6 +182,9 @@ function populateConfig(callback = null) { // Get configuration settings, popula
                 // Brewfather Tab
                 $('input[name="brewfatherKey"]').val(config.brewfatherKey);
 
+                // Brewfather Tab
+                $('input[name="userTargetURL"]').val(config.userTargetURL);
+
                 // Grainfather Tab
                 $('input[name="grainfatherURL_red"]').val(config.Red.grainfatherURL);
                 $('input[name="grainfatherURL_green"]').val(config.Green.grainfatherURL);
@@ -305,6 +308,9 @@ function processPost(obj) { // Disable buttons and call POST handler for form
             break;
         case "#brewfather":
             processBrewfatherPost(url, obj);
+            break;
+        case "#usertarget":
+            processUserTargetPost(url, obj);
             break;
         case "#grainfather":
             processGrainfatherPost(url, obj);
@@ -474,6 +480,19 @@ function processBrewfatherPost(url, obj) { // Handle Brewfather posts
     };
     postData(url, data);
 }
+
+function processUserTargetPost(url, obj) { // Handle User Target posts
+    // Get form data
+    var $form = $(obj.form),
+        userTargetKeyVal = $form.find("input[name='userTargetURL']").val();
+
+    // Process post
+    data = {
+        userTargetURL: userTargetKeyVal
+    };
+    postData(url, data);
+}
+
 
 function processGrainfatherPost(url, obj) { // Handle Grainfather posts
     // Get form data

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ v1.2.0 - Jan 9, 2023 - Fix OLED & Refactor LCD Code
 - Refactor LCD code to combine "D32 TFT" and "ESPI TFT" code
 - Replace existing M5 libraries with (existing) ESPI TFT library
 - Add new "User Target" data destination
+- Add support for OLED display at pins 17 & 18
 
 
 v1.1.3 - Aug 18, 2022 - Fix WiFi Manager

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,15 @@ Changelog
 
 
 
+v1.2.0 - Jan 9, 2023 - Fix OLED & Refactor LCD Code
+---------------------------------------------------
+
+- Fix OLED firmware
+- Refactor LCD code to combine "D32 TFT" and "ESPI TFT" code
+- Replace existing M5 libraries with (existing) ESPI TFT library
+- Add new "User Target" data destination
+
+
 v1.1.3 - Aug 18, 2022 - Fix WiFi Manager
 ----------------------------------------
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -196,26 +196,49 @@ lib_deps =
     bodmer/TFT_eSPI @ 2.4.72 ; https://github.com/Bodmer/TFT_eSPI.git
 build_type = ${common.build_type}
 
-[env:m5stickc]   ; M5Stack M5Stick-C
-board = m5stick-c
-board_build.f_cpu = 240000000L
+
+[env:m5stickc_plus]
+board = esp32dev
 platform = ${common.platform}
 ; platform_packages = ${common.platform_packages}
 framework = ${common.framework}
+; The M5StickC Plus has 4MB of flash. Use the custom 4MB partition to allow enough space
+; for both OTA and SPIFFS.
 board_build.partitions = ${common.board_build.partitions}
 upload_speed = 1500000
 monitor_speed = ${common.monitor_speed}
 monitor_filters = ${common.monitor_filters}
-; This can/will be set in tools/get_port.py
-; upload_port = {common.upload_port}
-; monitor_port = ${common.monitor_port}
 monitor_dtr = ${common.monitor_dtr}
 monitor_rts = ${common.monitor_rts}
 build_flags =
     ${common.build_flags}
+    ; -DM5STICKC_PLUS
     -DLCD_TFT_M5STICKC=1
+    -DLCD_TFT_ESPI=1
     -DDISABLE_OTA_UPDATES
+;    -DBUTTON_NO_PULLUP=1
+    -DBUTTON_INVERT
+    -DLCD_TFT_ESPI=1
+    -DAXP192=1
+    ; -DDISABLE_OTA_UPDATES=1
+    -DUSER_SETUP_LOADED=1
+    -DST7789_DRIVER=1
+    -DTFT_WIDTH=135
+    -DTFT_HEIGHT=240
+    -DCGRAM_OFFSET=1
+    -DTFT_MISO=-1
+    -DTFT_MOSI=15
+    -DTFT_SCLK=13
+    -DTFT_CS=5
+    -DTFT_DC=23
+    -DTFT_RST=18
+    -DLOAD_GFXFF=1
+    -DWIFI_RESET_BUTTON_GPIO=37
+    -DDISABLE_OTA_UPDATES
+;    -DBOARD_RESET_BUTTON_GPIO=39
 lib_deps =
     ${common.lib_deps}
-    m5stack/M5StickC @ 0.2.0
+    bodmer/TFT_eSPI @ 2.4.79 ; https://github.com/Bodmer/TFT_eSPI.git
+    tanakamasayuki/I2C AXP192 Power management@^1.0.4
 build_type = ${common.build_type}
+check_skip_packages = yes

--- a/platformio.ini
+++ b/platformio.ini
@@ -66,7 +66,7 @@ lib_deps =
     https://github.com/thorrak/Arduino-Log.git ; // Need this until ArduinoLog merges https://github.com/thijse/Arduino-Log/pull/23 
     https://github.com/lbussy/esptelnet.git
     https://github.com/me-no-dev/ESPAsyncWebServer.git
-    https://github.com/tzapu/WiFiManager.git#e0c5fb7daf4c44f2753fdc7325b9d47ad154ed30 ;#feature_asyncwebserver
+    https://github.com/thorrak/WiFiManager.git#feature_asyncwebserver
     h2zero/NimBLE-Arduino @ 1.3.4  ; https://github.com/h2zero/NimBLE-Arduino.git
     256dpi/MQTT @ 2.4.8
     lbussy/LCBUrl @ ^1.1.7

--- a/src/bridge_lcd.cpp
+++ b/src/bridge_lcd.cpp
@@ -93,25 +93,22 @@ void bridge_lcd::init() {
         oled_display->resetOrientation();
     }
     oled_display->setFont(ArialMT_Plain_10);
-#elif defined(LCD_TFT)
-    tft = new TFT_eSPI();
+
+
+#elif defined(LCD_TFT_ESPI) || defined(LCD_TFT)
+    tft = new TFT_eSPI(TFT_WIDTH, TFT_HEIGHT);
     tft->init();
-    tft->setFreeFont(&FreeSans12pt7b);
-    tft->setSwapBytes(true);
-    tft->initDMA();
     reinit();
 
-    tft->setTextColor(TFT_WHITE, TFT_BLACK);  // Not sure if we need this, or if it defaults to white/black
+#if defined(LCD_TFT)
+    tft->setFreeFont(&FreeSans12pt7b);
+#endif // LCD_TFT
 
 #ifdef TFT_BACKLIGHT
     pinMode(TFT_BACKLIGHT, OUTPUT);
     digitalWrite(TFT_BACKLIGHT, HIGH);
 #endif // TFT_BACKLIGHT
 
-#elif defined(LCD_TFT_ESPI)
-    tft = new TFT_eSPI(TFT_WIDTH, TFT_HEIGHT);
-    tft->init();
-    reinit();
 #endif // LCD_TFT_ESPI
 }
 

--- a/src/bridge_lcd.cpp
+++ b/src/bridge_lcd.cpp
@@ -533,7 +533,8 @@ bool bridge_lcd::i2c_device_at_address(byte address, int sda_pin, int scl_pin) {
     // multiple OLED ESP32 boards
     byte error;
 
-    Wire.begin(sda_pin, scl_pin);
+   if(!Wire.begin(sda_pin, scl_pin))
+       return false;  // Failed to initialize twowire on selected sda/scl
     Wire.beginTransmission(address);
     error = Wire.endTransmission();
 

--- a/src/bridge_lcd.cpp
+++ b/src/bridge_lcd.cpp
@@ -79,7 +79,17 @@ void bridge_lcd::init() {
             oled_display = new SSD1306Wire(0x3c, 4, 15);
         } else {
             digitalWrite(16, LOW);                    // We weren't able to find the TTGO board, so reset the pin
-            oled_display = new SSD1306Wire(0x3c, 21, 22); // ... and just default to the "sleeve" configuration
+
+            pinMode(21, OUTPUT); 
+            digitalWrite(21, LOW); // Set GPIO16 low to reset OLED 
+            delay(50); 
+            digitalWrite(21, HIGH); // While OLED is running, must set GPIO16 in high 
+            if (i2c_device_at_address(0x3c, 17, 18)) {
+                oled_display = new SSD1306Wire(0x3c, 17, 18);
+            } else {
+                digitalWrite(21, LOW);                    // We weren't able to find the TTGO board, so reset the pin
+                oled_display = new SSD1306Wire(0x3c, 21, 22); // ... and just default to the "sleeve" configuration
+            }
         }
     }
 

--- a/src/bridge_lcd.cpp
+++ b/src/bridge_lcd.cpp
@@ -1,6 +1,7 @@
 #include "bridge_lcd.h"
 #include "jsonconfig.h"
 #include <WiFi.h>
+#include <ArduinoLog.h>
 
 #ifdef LCD_SSD1306
 #include <Wire.h>
@@ -525,10 +526,13 @@ bool bridge_lcd::i2c_device_at_address(byte address, int sda_pin, int scl_pin) {
     // multiple OLED ESP32 boards
     byte error;
 
-   if(!Wire.begin(sda_pin, scl_pin))
-       return false;  // Failed to initialize twowire on selected sda/scl
+   if(!Wire.begin(sda_pin, scl_pin)) {
+        Log.error(F("Failed to initialize Wire on pin %d/%d\r\n"), sda_pin, scl_pin);
+        return false;  // Failed to initialize twowire on selected sda/scl
+   }
     Wire.beginTransmission(address);
     error = Wire.endTransmission();
+    Wire.end();
 
     if (error == 0) // No error means that a device responded
         return true;

--- a/src/bridge_lcd.h
+++ b/src/bridge_lcd.h
@@ -14,6 +14,7 @@
 #define SSD_LINE_CLEARANCE      2
 #define SSD1306_FONT            ArialMT_Plain_10
 #define TILTS_PER_PAGE          5 // The actual number is one fewer than this - the first row is used for headers
+#define HAVE_LCD                1
 
 #elif defined(LCD_TFT)
 
@@ -24,6 +25,7 @@
 #define TILTS_PER_PAGE          15 // The actual number is one fewer than this - the first row is used for headers
 #define TILT_FONT_SIZE          2
 #define MIN_PRESSURE            2000
+#define HAVE_LCD                1
 
 #elif defined(LCD_TFT_ESPI)
 
@@ -36,22 +38,16 @@
 #define FF17                    &FreeSans9pt7b
 #define GFXFF                   1
 #define TILTS_PER_PAGE          5 // The actual number is one fewer than this - the first row is used for headers
+#define HAVE_LCD                1
 
-#elif defined(LCD_TFT_M5STICKC)
-
-#include <M5StickC.h>
-
-#define TFT_M5STICKC_LINE_CLEARANCE 0
-#define GFXFF                   2
-#define TILTS_PER_PAGE          5 // The actual number is one fewer than this - the first row is used for headers
 
 #endif // LCD_SSD1306
 
-#ifdef TILTS_PER_PAGE
-#define HAVE_LCD                1
-#else
-#define HAVE_LCD                0
-#endif
+// #ifdef TILTS_PER_PAGE
+// #define HAVE_LCD                1
+// #else
+// #define HAVE_LCD                0
+// #endif
 
 #define SCREEN_TILT             0
 #define SCREEN_LOGO             1
@@ -91,7 +87,7 @@ private:
 
 #ifdef LCD_SSD1306
     SSD1306Wire *oled_display;
-#elif defined(LCD_TFT) || defined(LCD_TFT_ESPI) || defined(LCD_TFT_M5STICKC)
+#elif defined(LCD_TFT) || defined(LCD_TFT_ESPI)
     TFT_eSPI *tft;
 #endif // LCD_SSD1306
 

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -27,7 +27,8 @@
 #define BREWFATHER_MIN_KEY_LENGTH       5
 #define BREWERS_FRIEND_MIN_KEY_LENGTH   12
 #define BREWSTATUS_MIN_KEY_LENGTH       12
-#define GRAINFATHER_MIN_URL_LENGTH       44
+#define GRAINFATHER_MIN_URL_LENGTH      44
+#define USER_TARGET_MIN_URL_LENGTH      12
 
 class httpServer {
 public:

--- a/src/jsonconfig.cpp
+++ b/src/jsonconfig.cpp
@@ -223,6 +223,7 @@ DynamicJsonDocument Config::to_json() {
     obj["scriptsEmail"] = scriptsEmail;
     obj["brewersFriendKey"] = brewersFriendKey;
     obj["brewfatherKey"] = brewfatherKey;
+    obj["userTargetURL"] = userTargetURL;
     obj["mqttBrokerHost"] = mqttBrokerHost;
     obj["mqttBrokerPort"] = mqttBrokerPort;
     obj["mqttUsername"] = mqttUsername;
@@ -373,6 +374,11 @@ void Config::load_from_json(DynamicJsonDocument obj) {
     if (!obj["brewfatherKey"].isNull()) {
         const char *bk = obj["brewfatherKey"];
         strlcpy(brewfatherKey, bk, 65);
+    }
+
+    if (!obj["userTargetURL"].isNull()) {
+        const char *uturl = obj["userTargetURL"];
+        strlcpy(userTargetURL, uturl, 128);
     }
 
     if (!obj["mqttBrokerHost"].isNull()) {

--- a/src/jsonconfig.h
+++ b/src/jsonconfig.h
@@ -79,6 +79,7 @@ public:
     char scriptsEmail[256] = "";
     char brewersFriendKey[65] = "";
     char brewfatherKey[65] = "";
+    char userTargetURL[129] = "";
     char mqttBrokerHost[256] = "";
     uint16_t mqttBrokerPort = 1883;
     char mqttUsername[51] = "";

--- a/src/sendData.h
+++ b/src/sendData.h
@@ -26,6 +26,7 @@
 #define BREWFATHER_DELAY (15 * 60)     // 15 minute delay between pushes to Brewfather
 #define GRAINFATHER_DELAY (15 * 60)    // 15 minute delay between pushes to Grainfather
 #define CLOUD_DELAY (30 * 60)          // 30 minute delay between pushes to Parse Cloud
+#define USER_TARGET_DELAY (10 * 60)    // 10 minute delay between pushes to user specified send target
 
 #define BREWFATHER_MIN_KEY_LENGTH 5
 #define BREWERS_FRIEND_MIN_KEY_LENGTH 12
@@ -39,9 +40,11 @@
 
 // This is me being lazy and simplifying the reuse of code. The formats for Brewer's
 // Friend and Brewfather are basically the same so I'm combining them together
-// in one function
+// in one function. I'm being even lazier by adding a user defined "send target"
+// (user specified URL) to the same code block.
 #define BF_MEANS_BREWFATHER 1
 #define BF_MEANS_BREWERS_FRIEND 2
+#define BF_MEANS_USER_TARGET 3
 
 class dataSendHandler
 {


### PR DESCRIPTION
This PR refactors the LCD code, consolidating the "D32 TFT" and "ESPI TFT" code. This also substantially refactors the "M5" target to utilize (largely) the same code as the "ESPI TFT" target.

Additionally, this PR adds a new "custom user target" which sends the same JSON message as is sent to Brewfather and Brewer's Friend as requested by a HBT user. This functionality is currently untested. 