### PR TITLE
Fix Logo Color on TFT

### DIFF
--- a/src/bridge_lcd.cpp
+++ b/src/bridge_lcd.cpp
@@ -108,6 +108,7 @@ void bridge_lcd::init() {
 #elif defined(LCD_TFT_ESPI) || defined(LCD_TFT)
     tft = new TFT_eSPI(TFT_WIDTH, TFT_HEIGHT);
     tft->init();
+    tft->setSwapBytes(true);
     reinit();
 
 #if defined(LCD_TFT)


### PR DESCRIPTION
Fix #228 for Lolin D32 Pro & Lolin TFT combination. 