### PR TITLE
Add additional information to the Home Assistant MQTT Auto Discovery messages

### DIFF
--- a/src/sendData.h
+++ b/src/sendData.h
@@ -89,6 +89,7 @@ private:
     void prepare_gravity_payload(const char* tilt_color, const char* tilt_topic);
     void prepare_battery_payload(const char* tilt_color, const char* tilt_topic);
     void prepare_general_payload(uint8_t tilt_index, const char* tilt_topic);
+    void enrich_announcement(const char* topic, const char* tilt_color, StaticJsonDocument<512>& payload);
 
 };
 


### PR DESCRIPTION
This tags the uptime as being an "additional attribute" (thereby preventing the same reading being sent repeatedly from updating the 'last changed' timestamp), and adds additional device configuration information to the announcement. 

Closes #248