### PR TITLE
Replace Display Library

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -63,8 +63,7 @@ lib_deps =
     mathieucarbou/ESPAsyncWebServer @ 3.5.1  ; https://github.com/mathieucarbou/ESPAsyncWebServer
     mathieucarbou/AsyncTCP @ ^3.3.2  ; https://github.com/mathieucarbou/AsyncTCP
 espi_lib_deps = 
-    https://github.com/Bodmer/TFT_eSPI.git#5793878d24161c1ed23ccb136f8564f332506d53 ; master as of 7/6/24
-;    bodmer/TFT_eSPI @ 2.4.79 ; https://github.com/Bodmer/TFT_eSPI.git
+    lovyan03/LovyanGFX @ ^1.1.16  ; https://github.com/lovyan03/LovyanGFX
 build_type = release ; debug
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -109,22 +108,10 @@ monitor_rts = ${common.monitor_rts}
 build_flags = 
     ${common.build_flags}
     -D LCD_TFT=1
-    -D USER_SETUP_LOADED=1
-    -D ILI9341_DRIVER=1
     -D TFT_WIDTH=240
     -D TFT_HEIGHT=320
-    -D CGRAM_OFFSET=1
-    -D SMOOTH_FONT=1
-    -D TFT_BACKLIGHT_ON=1
-    -D LOAD_GFXFF=1
     -D TOUCH_CS=12
     -D HARDWARE_VERSION="D32 Pro TFT"
-    -DTFT_MISO=19
-    -DTFT_MOSI=23
-    -DTFT_SCLK=18
-    -DTFT_CS=14
-    -DTFT_DC=27
-    -DTFT_RST=33
     -D TFT_BL=32
 lib_deps = 
     ${common.lib_deps}
@@ -151,19 +138,9 @@ build_flags =
     ${common.build_flags}
     -DLCD_TFT_ESPI=1
     -DDISABLE_OTA_UPDATES=1
-    -DUSER_SETUP_LOADED=1
-    -DST7789_DRIVER=1
     -DTFT_WIDTH=135
     -DTFT_HEIGHT=240
-    -DCGRAM_OFFSET=1
-    -DTFT_MISO=-1
-    -DTFT_MOSI=19
-    -DTFT_SCLK=18
-    -DTFT_CS=5
-    -DTFT_DC=16
-    -DTFT_RST=23
     -DTFT_BL=4
-    -DLOAD_GFXFF=1
     -D HARDWARE_VERSION="ESPI TFT"
 lib_deps = 
     ${common.lib_deps}
@@ -187,22 +164,10 @@ build_flags =
     -DLCD_TFT_ESPI=1
     -DDISABLE_OTA_UPDATES
     -DBUTTON_INVERT
-    -DLCD_TFT_ESPI=1
     -DAXP192=1
-    -DUSER_SETUP_LOADED=1
-    -DST7789_DRIVER=1
     -DTFT_WIDTH=135
     -DTFT_HEIGHT=240
-    -DCGRAM_OFFSET=1
-    -DTFT_MISO=-1
-    -DTFT_MOSI=15
-    -DTFT_SCLK=13
-    -DTFT_CS=5
-    -DTFT_DC=23
-    -DTFT_RST=18
-    -DLOAD_GFXFF=1
     -DWIFI_RESET_BUTTON_GPIO=37
-    -DDISABLE_OTA_UPDATES
     -D HARDWARE_VERSION="M5"
 lib_deps = 
     ${common.lib_deps}
@@ -256,35 +221,10 @@ monitor_rts = ${common.monitor_rts}
 build_flags = 
     ${common.build_flags}
     -DLCD_TFT_ESPI=1
-    -DDISABLE_OTA_UPDATES
-
     -DDISABLE_OTA_UPDATES=1
-    ; -DUSER_SETUP_LOADED=1
-    -DST7789_2_DRIVER=1
     -DTFT_WIDTH=170
     -DTFT_HEIGHT=320
-    ; -DCGRAM_OFFSET=1
-    -DLOAD_GFXFF=1
-
-    -DPIN_LCD_BL=38
-
-    -DPIN_LCD_D0=39
-    -DPIN_LCD_D1=40
-    -DPIN_LCD_D2=41
-    -DPIN_LCD_D3=42
-    -DPIN_LCD_D4=45
-    -DPIN_LCD_D5=46
-    -DPIN_LCD_D6=47
-    -DPIN_LCD_D7=48
-
     -DPIN_POWER_ON=15
-
-    -DPIN_LCD_RES=5
-    -DPIN_LCD_CS=6
-    -DPIN_LCD_DC=7
-    -DPIN_LCD_WR=8
-    -DPIN_LCD_RD=9
-
     -DBOARD_RESET_BUTTON_GPIO=0
     -DWIFI_RESET_BUTTON_GPIO=14
     -D HARDWARE_VERSION="S3 TDisplay"

--- a/src/JsonKeys.h
+++ b/src/JsonKeys.h
@@ -70,6 +70,5 @@ constexpr auto mqttPushEvery = "mqttPushEvery";
 constexpr auto mqttUsername = "mqttUsername";
 constexpr auto mqttPassword = "mqttPassword";
 constexpr auto mqttTopic = "mqttTopic";
-
 }
 

--- a/src/bridge_lcd.h
+++ b/src/bridge_lcd.h
@@ -22,13 +22,12 @@
 #elif defined(LCD_TFT) || defined(LCD_TFT_ESPI)
 
 // For the LCD_TFT displays, we're connecting via SPI
-#define DISABLE_ALL_LIBRARY_WARNINGS
-#include <TFT_eSPI.h>
-#undef DISABLE_ALL_LIBRARY_WARNINGS
+#include <LovyanGFX.hpp>
+#include "lovyan_config.h"
 #include <SPI.h>
 
 #define FF_NORMAL               &FreeSans9pt7b
-#define GFXFF                   1
+
 #define HAVE_LCD                1
 
 #if defined(LCD_TFT)
@@ -95,7 +94,7 @@ private:
 #ifdef LCD_SSD1306
     SSD1306Wire *oled_display;
 #elif defined(LCD_TFT) || defined(LCD_TFT_ESPI)
-    TFT_eSPI *tft;
+    lgfx::LGFX_Device *tft;
 #endif // LCD_SSD1306
 
     bool displaying_wifi_dc_screen = false;

--- a/src/bridge_lcd_impl.cpp
+++ b/src/bridge_lcd_impl.cpp
@@ -127,12 +127,23 @@ void bridge_lcd::init() {
 
 
 #elif defined(LCD_TFT_ESPI) || defined(LCD_TFT)
-    tft = new TFT_eSPI(TFT_WIDTH, TFT_HEIGHT);
+    // Initialize appropriate LovyanGFX configuration based on hardware
+#if defined(LCD_TFT)
+    tft = new LGFX_D32_Pro();
+#elif defined(LCD_TFT_M5STICKC)
+    tft = new LGFX_M5StickC();
+#elif defined(ESP32S3)
+    tft = new LGFX_S3_TDisplay();
+    // tft = new LGFX();
+#else
+    tft = new LGFX_TFT_ESPI();
+#endif
+    
     tft->init();
     tft->setSwapBytes(true);
     reinit();
 
-    tft->setFreeFont(FF_NORMAL);
+    tft->setFont(&FreeSans9pt7b);
 
 #ifdef TFT_BACKLIGHT
     pinMode(TFT_BACKLIGHT, OUTPUT);
@@ -166,7 +177,7 @@ void bridge_lcd::checkTouch()
 #ifdef TOUCH_CS
 
     uint16_t x = 0, y = 0; // Touch coordinates (not used here)
-    bool touched = tft->getTouch(&x, &y, MIN_PRESSURE);
+    bool touched = tft->getTouch(&x, &y);
 
     if (touched && ! touchLatch && ! setWiFiPushed) {
         // New touch, not currently waiting to process a touch elsewhere
@@ -223,30 +234,30 @@ void bridge_lcd::print_line(const char *left_text, const char *middle_text, cons
     oled_display->drawString(128, starting_pixel_row, right_text);
 #elif defined(LCD_TFT)
     int16_t starting_pixel_row = 0;
-    starting_pixel_row = (tft->fontHeight(GFXFF)) * (line - 1) + 2;
+    starting_pixel_row = (tft->fontHeight()) * (line - 1) + 2;
 
     if(add_gutter)  // We need space to the left to be able to display the Tilt color block
-        tft->drawString(left_text, 25, starting_pixel_row, GFXFF);
+        tft->drawString(left_text, 25, starting_pixel_row);
     else
-        tft->drawString(left_text, 1, starting_pixel_row, GFXFF);
+        tft->drawString(left_text, 1, starting_pixel_row);
 
     yield();
-    tft->drawString(middle_text, 134, starting_pixel_row, GFXFF);
+    tft->drawString(middle_text, 134, starting_pixel_row);
     yield();
     if(add_gutter)
-        tft->drawString(right_text, 300 - tft->textWidth(right_text, GFXFF), starting_pixel_row, GFXFF);
+        tft->drawString(right_text, 300 - tft->textWidth(right_text), starting_pixel_row);
     else
-        tft->drawString(right_text, 319 - tft->textWidth(right_text, GFXFF), starting_pixel_row, GFXFF);
+        tft->drawString(right_text, 319 - tft->textWidth(right_text), starting_pixel_row);
 #elif defined(LCD_TFT_ESPI)
     // ignore left text as we color the text by the tilt
     int16_t starting_pixel_row = 0;
 
     starting_pixel_row = (TFT_ESPI_LINE_CLEARANCE + TFT_ESPI_FONT_SIZE) * (line - 1) + TFT_ESPI_LINE_CLEARANCE;
 
-    // TFT_eSPI::drawString(const char *string, int32_t poX, int32_t poY, uint8_t font_number)
+    // LovyanGFX::drawString(const char *string, int32_t poX, int32_t poY)
     // TODO - Replace middle_text with left_text (and skip all middle text instead)
-    tft->drawString(middle_text, 0, starting_pixel_row, GFXFF);
-    tft->drawString(right_text, tft->width() / 2, starting_pixel_row, GFXFF);
+    tft->drawString(middle_text, 0, starting_pixel_row);
+    tft->drawString(right_text, tft->width() / 2, starting_pixel_row);
 #endif
 }
 
@@ -256,7 +267,7 @@ void bridge_lcd::clear() {
     oled_display->clear();
     oled_display->setFont(SSD1306_FONT);
 #elif defined(LCD_TFT) || defined(LCD_TFT_ESPI)
-    tft->fillScreen(TFT_BLACK);
+    tft->fillScreen(0x0000);  // Black color in 16-bit RGB565 format
 #endif
     yield();
 }
@@ -280,20 +291,20 @@ void bridge_lcd::print_tilt_to_line(tiltHydrometer *tilt, uint8_t line) {
     print_line(tilt_color_names[tilt->m_color], temp, gravity, line, true);
 
 #ifdef LCD_TFT
-    uint16_t fHeight = tft->fontHeight(GFXFF);
+    uint16_t fHeight = tft->fontHeight();
     if (tilt_text_colors[tilt->m_color] == 0xFFFF) { // White outline, black square
         tft->fillRect( // White square
             0,
             fHeight * (line - 1) + 2,
             15,
             fHeight - 8,
-            TFT_WHITE);
+            0xFFFF);  // White in RGB565
         tft->fillRect( // Black square
             1,
             fHeight * (line - 1) + 3,
             13,
             fHeight - 10,
-            TFT_BLACK);
+            0x0000);  // Black in RGB565
     } else {
         // All else
         tft->fillRect(
@@ -304,7 +315,7 @@ void bridge_lcd::print_tilt_to_line(tiltHydrometer *tilt, uint8_t line) {
             tilt_text_colors[tilt->m_color]);
     }
 #elif defined(LCD_TFT_ESPI)
-    tft->setTextColor(TFT_WHITE);
+    tft->setTextColor(0xFFFF);  // White in RGB565
 #endif
 }
 
@@ -357,7 +368,7 @@ void bridge_lcd::display_logo_internal() {
         oled_logo_bits,
         oled_logo_width,
         oled_logo_height,
-        TFT_WHITE);
+        0xFFFF);  // White in RGB565
     display();
 #endif
 }

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -185,7 +185,6 @@ bool updateJsonSetting(const JsonDocument& json, const char* key, uint16_t& conf
 
 bool processCalibrationSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     uint8_t failCount = 0;
-    bool saveSettings = false;
 
     // Calibration settings
     if(!updateJsonSettingBool(json, CalibrationKeys::applyCalibration, config.applyCalibration))
@@ -197,11 +196,9 @@ bool processCalibrationSettings(const JsonDocument& json, bool triggerUpstreamUp
     // Save
     if(failCount>0) {
         Log.error(F("Error: Invalid upstream configuration.\r\n"));
-    } else if (saveSettings) {
-        if (!config.save()) {
-            Log.error(F("Error: Unable to save calibration configuration data.\r\n"));
-            failCount++;
-        }
+    } else if (!config.save()) {
+        Log.error(F("Error: Unable to save calibration configuration data.\r\n"));
+        failCount++;
     }
 
     return failCount == 0;
@@ -210,7 +207,6 @@ bool processCalibrationSettings(const JsonDocument& json, bool triggerUpstreamUp
 
 bool processFermentrackSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     uint8_t failCount = 0;
-    bool saveSettings = false;
 
     bool update_legacy = false;
     bool update_ft2 = false;
@@ -276,7 +272,6 @@ bool processFermentrackSettings(const JsonDocument& json, bool triggerUpstreamUp
 
 bool processGoogleSheetsSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     uint8_t failCount = 0;
-    bool saveSettings = false;
 
 
     if(!updateJsonSetting(json, GoogleSheetsSettings::scriptsURL, config.scriptsURL, 256))
@@ -301,11 +296,9 @@ bool processGoogleSheetsSettings(const JsonDocument& json, bool triggerUpstreamU
     // Save
     if(failCount>0) {
         Log.error(F("Error: Invalid Google Sheets configuration.\r\n"));
-    } else if (saveSettings) {
-        if (!config.save()) {
-            Log.error(F("Error: Unable to save Google Sheets configuration data.\r\n"));
-            failCount++;
-        }
+    } else if (!config.save()) {
+        Log.error(F("Error: Unable to save Google Sheets configuration data.\r\n"));
+        failCount++;
     }
 
     return failCount == 0;
@@ -314,7 +307,6 @@ bool processGoogleSheetsSettings(const JsonDocument& json, bool triggerUpstreamU
 
 bool processBrewersFriendSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     uint8_t failCount = 0;
-    bool saveSettings = false;
 
 
     if(!updateJsonSetting(json, BrewersFriendSettings::brewersFriendKey, config.brewersFriendKey, 64))
@@ -326,11 +318,9 @@ bool processBrewersFriendSettings(const JsonDocument& json, bool triggerUpstream
     // Save
     if(failCount>0) {
         Log.error(F("Error: Invalid Brewer's Friend configuration.\r\n"));
-    } else if (saveSettings) {
-        if (!config.save()) {
-            Log.error(F("Error: Unable to save Brewer's Friend configuration data.\r\n"));
-            failCount++;
-        }
+    } else if (!config.save()) {
+        Log.error(F("Error: Unable to save Brewer's Friend configuration data.\r\n"));
+        failCount++;
     }
 
     return failCount == 0;
@@ -339,7 +329,6 @@ bool processBrewersFriendSettings(const JsonDocument& json, bool triggerUpstream
 
 bool processBrewfatherSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     uint8_t failCount = 0;
-    bool saveSettings = false;
 
 
     if(!updateJsonSetting(json, BrewfatherSettings::brewfatherKey, config.brewfatherKey, 64))
@@ -351,11 +340,9 @@ bool processBrewfatherSettings(const JsonDocument& json, bool triggerUpstreamUpd
     // Save
     if(failCount>0) {
         Log.error(F("Error: Invalid Brewfather configuration.\r\n"));
-    } else if (saveSettings) {
-        if (!config.save()) {
-            Log.error(F("Error: Unable to save Brewfather configuration data.\r\n"));
-            failCount++;
-        }
+    } else  if (!config.save()) {
+        Log.error(F("Error: Unable to save Brewfather configuration data.\r\n"));
+        failCount++;
     }
 
     return failCount == 0;
@@ -364,7 +351,6 @@ bool processBrewfatherSettings(const JsonDocument& json, bool triggerUpstreamUpd
 
 bool processUserTargetSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     uint8_t failCount = 0;
-    bool saveSettings = false;
 
 
     if(!updateJsonSetting(json, UserTargetSettings::userTargetURL, config.userTargetURL, 128))
@@ -376,11 +362,9 @@ bool processUserTargetSettings(const JsonDocument& json, bool triggerUpstreamUpd
     // Save
     if(failCount>0) {
         Log.error(F("Error: Invalid user target configuration.\r\n"));
-    } else if (saveSettings) {
-        if (!config.save()) {
-            Log.error(F("Error: Unable to save user target configuration data.\r\n"));
-            failCount++;
-        }
+    } else if (!config.save()) {
+        Log.error(F("Error: Unable to save user target configuration data.\r\n"));
+        failCount++;
     }
 
     return failCount == 0;
@@ -389,7 +373,6 @@ bool processUserTargetSettings(const JsonDocument& json, bool triggerUpstreamUpd
 
 bool processGrainfatherSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     uint8_t failCount = 0;
-    bool saveSettings = false;
 
     // Loop through each of the keys associated with the sheet names, and update the relevant config entry
     uint8_t i=0;
@@ -409,11 +392,9 @@ bool processGrainfatherSettings(const JsonDocument& json, bool triggerUpstreamUp
     // Save
     if(failCount>0) {
         Log.error(F("Error: Invalid Grainfather configuration.\r\n"));
-    } else if (saveSettings) {
-        if (!config.save()) {
-            Log.error(F("Error: Unable to save Grainfather configuration data.\r\n"));
-            failCount++;
-        }
+    } else if (!config.save()) {
+        Log.error(F("Error: Unable to save Grainfather configuration data.\r\n"));
+        failCount++;
     }
 
     return failCount == 0;
@@ -422,7 +403,6 @@ bool processGrainfatherSettings(const JsonDocument& json, bool triggerUpstreamUp
 
 bool processBrewstatusSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     uint8_t failCount = 0;
-    bool saveSettings = false;
 
 
     if(!updateJsonSetting(json, BrewstatusSettings::brewstatusURL, config.brewstatusURL, 256))
@@ -439,11 +419,9 @@ bool processBrewstatusSettings(const JsonDocument& json, bool triggerUpstreamUpd
     // Save
     if(failCount>0) {
         Log.error(F("Error: Invalid Brewstatus configuration.\r\n"));
-    } else if (saveSettings) {
-        if (!config.save()) {
-            Log.error(F("Error: Unable to save Brewstatus configuration data.\r\n"));
-            failCount++;
-        }
+    } else if (!config.save()) {
+        Log.error(F("Error: Unable to save Brewstatus configuration data.\r\n"));
+        failCount++;
     }
 
     return failCount == 0;
@@ -452,7 +430,6 @@ bool processBrewstatusSettings(const JsonDocument& json, bool triggerUpstreamUpd
 
 bool processTaplistioSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     uint8_t failCount = 0;
-    bool saveSettings = false;
 
 
     if(!updateJsonSetting(json, TaplistioSettings::taplistioURL, config.taplistioURL, 256))
@@ -468,11 +445,9 @@ bool processTaplistioSettings(const JsonDocument& json, bool triggerUpstreamUpda
     // Save
     if(failCount>0) {
         Log.error(F("Error: Invalid Taplist.io configuration.\r\n"));
-    } else if (saveSettings) {
-        if (!config.save()) {
-            Log.error(F("Error: Unable to save Taplist.io configuration data.\r\n"));
-            failCount++;
-        }
+    } else if (!config.save()) {
+        Log.error(F("Error: Unable to save Taplist.io configuration data.\r\n"));
+        failCount++;
     }
 
     return failCount == 0;
@@ -480,7 +455,6 @@ bool processTaplistioSettings(const JsonDocument& json, bool triggerUpstreamUpda
 
 bool processMqttSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     uint8_t failCount = 0;
-    bool saveSettings = false;
 
 
     if(!updateJsonSetting(json, MQTTSettings::mqttBrokerHost, config.mqttBrokerHost, sizeof(config.mqttBrokerHost)))
@@ -511,11 +485,9 @@ bool processMqttSettings(const JsonDocument& json, bool triggerUpstreamUpdate) {
     // Save
     if(failCount>0) {
         Log.error(F("Error: Invalid Taplist.io configuration.\r\n"));
-    } else if (saveSettings) {
-        if (!config.save()) {
-            Log.error(F("Error: Unable to save Taplist.io configuration data.\r\n"));
-            failCount++;
-        }
+    } else if (!config.save()) {
+        Log.error(F("Error: Unable to save Taplist.io configuration data.\r\n"));
+        failCount++;
     }
 
     return failCount == 0;

--- a/src/jsonconfig.cpp
+++ b/src/jsonconfig.cpp
@@ -211,21 +211,21 @@ JsonDocument Config::to_json() {
     obj[FermentrackSettings::fermentrackDeviceID] = fermentrackDeviceID;
     obj[FermentrackSettings::fermentrackAPIKey] = fermentrackAPIKey;
 
-    obj["brewstatusURL"] = brewstatusURL;
-    obj["brewstatusPushEvery"] = brewstatusPushEvery;
-    obj["taplistioURL"] = taplistioURL;
-    obj["taplistioPushEvery"] = taplistioPushEvery;
-    obj["scriptsURL"] = scriptsURL;
-    obj["scriptsEmail"] = scriptsEmail;
-    obj["brewersFriendKey"] = brewersFriendKey;
-    obj["brewfatherKey"] = brewfatherKey;
-    obj["userTargetURL"] = userTargetURL;
-    obj["mqttBrokerHost"] = mqttBrokerHost;
-    obj["mqttBrokerPort"] = mqttBrokerPort;
-    obj["mqttUsername"] = mqttUsername;
-    obj["mqttPassword"] = mqttPassword;
-    obj["mqttTopic"] = mqttTopic;
-    obj["mqttPushEvery"] = mqttPushEvery;
+    obj[BrewstatusSettings::brewstatusURL] = brewstatusURL;
+    obj[BrewstatusSettings::brewstatusPushEvery] = brewstatusPushEvery;
+    obj[TaplistioSettings::taplistioURL] = taplistioURL;
+    obj[TaplistioSettings::taplistioPushEvery] = taplistioPushEvery;
+    obj[GoogleSheetsSettings::scriptsURL] = scriptsURL;
+    obj[GoogleSheetsSettings::scriptsEmail] = scriptsEmail;
+    obj[BrewersFriendSettings::brewersFriendKey] = brewersFriendKey;
+    obj[BrewfatherSettings::brewfatherKey] = brewfatherKey;
+    obj[UserTargetSettings::userTargetURL] = userTargetURL;
+    obj[MQTTSettings::mqttBrokerHost] = mqttBrokerHost;
+    obj[MQTTSettings::mqttBrokerPort] = mqttBrokerPort;
+    obj[MQTTSettings::mqttUsername] = mqttUsername;
+    obj[MQTTSettings::mqttPassword] = mqttPassword;
+    obj[MQTTSettings::mqttTopic] = mqttTopic;
+    obj[MQTTSettings::mqttPushEvery] = mqttPushEvery;
 
     return obj;
 }
@@ -361,81 +361,81 @@ void Config::load_from_json(JsonDocument obj) {
 
 
     // BrewStatus Settings
-    if (!obj["brewstatusURL"].isNull()) {
-        const char *bu = obj["brewstatusURL"];
+    if (!obj[BrewstatusSettings::brewstatusURL].isNull()) {
+        const char *bu = obj[BrewstatusSettings::brewstatusURL];
         strlcpy(brewstatusURL, bu, 256);
     }
 
-    if (!obj["brewstatusPushEvery"].isNull()) {
-        int pe = obj["brewstatusPushEvery"];
+    if (!obj[BrewstatusSettings::brewstatusPushEvery].isNull()) {
+        int pe = obj[BrewstatusSettings::brewstatusPushEvery];
         brewstatusPushEvery = pe;
     }
 
     // TaplistIO Settings
-    if (!obj["taplistioURL"].isNull()) {
-        const char *tu = obj["taplistioURL"];
+    if (!obj[TaplistioSettings::taplistioURL].isNull()) {
+        const char *tu = obj[TaplistioSettings::taplistioURL];
         strlcpy(taplistioURL, tu, 256);
     }
 
-    if (!obj["taplistioPushEvery"].isNull()) {
-        taplistioPushEvery = obj["taplistioPushEvery"];
+    if (!obj[TaplistioSettings::taplistioPushEvery].isNull()) {
+        taplistioPushEvery = obj[TaplistioSettings::taplistioPushEvery];
     }
 
     // Google Scripts Settings
-    if (!obj["scriptsURL"].isNull()) {
-        const char *su = obj["scriptsURL"];
+    if (!obj[GoogleSheetsSettings::scriptsURL].isNull()) {
+        const char *su = obj[GoogleSheetsSettings::scriptsURL];
         strlcpy(scriptsURL, su, 256);
     }
 
-    if (!obj["scriptsEmail"].isNull()) {
-        const char *se = obj["scriptsEmail"];
+    if (!obj[GoogleSheetsSettings::scriptsEmail].isNull()) {
+        const char *se = obj[GoogleSheetsSettings::scriptsEmail];
         strlcpy(scriptsEmail, se, 256);
     }
 
     // Brewers Friend
-    if (!obj["brewersFriendKey"].isNull()) {
-        const char *bf = obj["brewersFriendKey"];
+    if (!obj[BrewersFriendSettings::brewersFriendKey].isNull()) {
+        const char *bf = obj[BrewersFriendSettings::brewersFriendKey];
         strlcpy(brewersFriendKey, bf, 65);
     }
 
     // Brewfather
-    if (!obj["brewfatherKey"].isNull()) {
-        const char *bk = obj["brewfatherKey"];
+    if (!obj[BrewfatherSettings::brewfatherKey].isNull()) {
+        const char *bk = obj[BrewfatherSettings::brewfatherKey];
         strlcpy(brewfatherKey, bk, 65);
     }
 
     // User-defined Target Settings
-    if (!obj["userTargetURL"].isNull()) {
-        const char *uturl = obj["userTargetURL"];
+    if (!obj[UserTargetSettings::userTargetURL].isNull()) {
+        const char *uturl = obj[UserTargetSettings::userTargetURL];
         strlcpy(userTargetURL, uturl, 128);
     }
 
     // MQTT Settings
-    if (!obj["mqttBrokerHost"].isNull()) {
-        const char *mi = obj["mqttBrokerHost"];
+    if (!obj[MQTTSettings::mqttBrokerHost].isNull()) {
+        const char *mi = obj[MQTTSettings::mqttBrokerHost];
         strlcpy(mqttBrokerHost, mi, 256);
     }
 
-    if (!obj["mqttBrokerPort"].isNull()) {
-        mqttBrokerPort = int(obj["mqttBrokerPort"]);
+    if (!obj[MQTTSettings::mqttBrokerPort].isNull()) {
+        mqttBrokerPort = int(obj[MQTTSettings::mqttBrokerPort]);
     }
 
-    if (!obj["mqttUsername"].isNull()) {
-        const char *mu = obj["mqttUsername"];
+    if (!obj[MQTTSettings::mqttUsername].isNull()) {
+        const char *mu = obj[MQTTSettings::mqttUsername];
         strlcpy(mqttUsername, mu, 51);
     }
 
-    if (!obj["mqttPassword"].isNull()) {
-        const char *mp = obj["mqttPassword"];
+    if (!obj[MQTTSettings::mqttPassword].isNull()) {
+        const char *mp = obj[MQTTSettings::mqttPassword];
         strlcpy(mqttPassword, mp, 65);
     }
 
-    if (!obj["mqttTopic"].isNull()) {
-        const char *mt = obj["mqttTopic"];
+    if (!obj[MQTTSettings::mqttTopic].isNull()) {
+        const char *mt = obj[MQTTSettings::mqttTopic];
         strlcpy(mqttTopic, mt, 31);
     }
 
-    if (!obj["mqttPushEvery"].isNull()) {
-        mqttPushEvery = int(obj["mqttPushEvery"]);
+    if (!obj[MQTTSettings::mqttPushEvery].isNull()) {
+        mqttPushEvery = int(obj[MQTTSettings::mqttPushEvery]);
     }
 }

--- a/src/lovyan_config.h
+++ b/src/lovyan_config.h
@@ -1,0 +1,234 @@
+#ifndef TILTBRIDGE_LOVYAN_CONFIG_H
+#define TILTBRIDGE_LOVYAN_CONFIG_H
+
+#include <LovyanGFX.hpp>
+
+#if defined(LCD_TFT)
+// Configuration class for D32 Pro TFT (ILI9341)
+class LGFX_D32_Pro : public lgfx::LGFX_Device
+{
+    lgfx::Panel_ILI9341 _panel_instance;
+    lgfx::Bus_SPI _bus_instance;
+
+public:
+    LGFX_D32_Pro(void)
+    {
+        {
+            auto cfg = _bus_instance.config();
+            cfg.spi_host = VSPI_HOST;
+            cfg.spi_mode = 0;
+            cfg.freq_write = 40000000;
+            cfg.freq_read = 16000000;
+            cfg.spi_3wire = true;
+            cfg.use_lock = true;
+            cfg.dma_channel = SPI_DMA_CH_AUTO;
+            cfg.pin_sclk = 18;
+            cfg.pin_mosi = 23;
+            cfg.pin_miso = 19;
+            cfg.pin_dc = 27;
+            _bus_instance.config(cfg);
+            _panel_instance.setBus(&_bus_instance);
+        }
+
+        {
+            auto cfg = _panel_instance.config();
+            cfg.pin_cs = 14;
+            cfg.pin_rst = 33;
+            cfg.pin_busy = -1;
+            cfg.panel_width = 240;
+            cfg.panel_height = 320;
+            cfg.offset_x = 0;
+            cfg.offset_y = 0;
+            cfg.offset_rotation = 0;
+            cfg.dummy_read_pixel = 8;
+            cfg.dummy_read_bits = 1;
+            cfg.readable = true;
+            cfg.invert = false;
+            cfg.rgb_order = false;
+            cfg.dlen_16bit = false;
+            cfg.bus_shared = true;
+            _panel_instance.config(cfg);
+        }
+
+        setPanel(&_panel_instance);
+    }
+};
+
+#elif defined(LCD_TFT_M5STICKC)
+// Configuration class for M5StickC Plus
+class LGFX_M5StickC : public lgfx::LGFX_Device
+{
+    lgfx::Panel_ST7789 _panel_instance;
+    lgfx::Bus_SPI _bus_instance;
+
+public:
+    LGFX_M5StickC(void)
+    {
+        {
+            auto cfg = _bus_instance.config();
+            cfg.spi_host = VSPI_HOST;
+            cfg.spi_mode = 0;
+            cfg.freq_write = 40000000;
+            cfg.freq_read = 16000000;
+            cfg.spi_3wire = true;
+            cfg.use_lock = true;
+            cfg.dma_channel = SPI_DMA_CH_AUTO;
+            cfg.pin_sclk = 13;
+            cfg.pin_mosi = 15;
+            cfg.pin_miso = -1;
+            cfg.pin_dc = 23;
+            _bus_instance.config(cfg);
+            _panel_instance.setBus(&_bus_instance);
+        }
+
+        {
+            auto cfg = _panel_instance.config();
+            cfg.pin_cs = 5;
+            cfg.pin_rst = 18;
+            cfg.pin_busy = -1;
+            cfg.panel_width = 135;
+            cfg.panel_height = 240;
+            cfg.offset_x = 52;
+            cfg.offset_y = 40;
+            cfg.offset_rotation = 0;
+            cfg.dummy_read_pixel = 8;
+            cfg.dummy_read_bits = 1;
+            cfg.readable = true;
+            cfg.invert = true;
+            cfg.rgb_order = false;
+            cfg.dlen_16bit = false;
+            cfg.bus_shared = true;
+            _panel_instance.config(cfg);
+        }
+
+        setPanel(&_panel_instance);
+    }
+};
+
+#elif defined(ESP32S3)
+// Configuration class for ESP32-S3 TDisplay
+class LGFX_S3_TDisplay : public lgfx::LGFX_Device
+{
+    lgfx::Panel_ST7789 _panel_instance;
+    lgfx::Bus_Parallel8 _bus_instance;
+    lgfx::Light_PWM _light_instance;
+
+public:
+    LGFX_S3_TDisplay(void)
+    {
+        {
+            auto cfg = _bus_instance.config();
+            cfg.freq_write = 20000000;
+            cfg.pin_wr = 8;
+            cfg.pin_rd = 9;
+            cfg.pin_rs = 7;
+            cfg.pin_d0 = 39;
+            cfg.pin_d1 = 40;
+            cfg.pin_d2 = 41;
+            cfg.pin_d3 = 42;
+            cfg.pin_d4 = 45;
+            cfg.pin_d5 = 46;
+            cfg.pin_d6 = 47;
+            cfg.pin_d7 = 48;
+            _bus_instance.config(cfg);
+            _panel_instance.setBus(&_bus_instance);
+        }
+
+        {
+            auto cfg = _panel_instance.config();
+            cfg.pin_cs = 6;
+            cfg.pin_rst = 5;
+            cfg.pin_busy = -1;
+            cfg.panel_width = 170;
+            cfg.panel_height = 320;
+            cfg.offset_x = 35;
+            cfg.offset_y = 0;
+            cfg.offset_rotation = 0;
+            cfg.dummy_read_pixel = 8;
+            cfg.dummy_read_bits = 1;
+            cfg.readable = true;
+            cfg.invert = true;
+            cfg.rgb_order = false;
+            cfg.dlen_16bit = false;
+            cfg.bus_shared = true;
+            _panel_instance.config(cfg);
+        }
+
+        {
+            auto cfg = _light_instance.config();
+            cfg.pin_bl = 38;
+            cfg.invert = false;
+            cfg.freq = 44100;
+            cfg.pwm_channel = 7;
+            _light_instance.config(cfg);
+            _panel_instance.setLight(&_light_instance);
+        }
+
+        setPanel(&_panel_instance);
+    }
+};
+
+#else
+// Configuration class for TFT_ESPI displays (ST7789)
+class LGFX_TFT_ESPI : public lgfx::LGFX_Device
+{
+    lgfx::Panel_ST7789 _panel_instance;
+    lgfx::Bus_SPI _bus_instance;
+    lgfx::Light_PWM _light_instance;
+
+public:
+    LGFX_TFT_ESPI(void)
+    {
+        {
+            auto cfg = _bus_instance.config();
+            cfg.spi_host = VSPI_HOST;
+            cfg.spi_mode = 0;
+            cfg.freq_write = 40000000;
+            cfg.freq_read = 16000000;
+            cfg.spi_3wire = true;
+            cfg.use_lock = true;
+            cfg.dma_channel = SPI_DMA_CH_AUTO;
+            cfg.pin_sclk = 18;
+            cfg.pin_mosi = 19;
+            cfg.pin_miso = -1;
+            cfg.pin_dc = 16;
+            _bus_instance.config(cfg);
+            _panel_instance.setBus(&_bus_instance);
+        }
+
+        {
+            auto cfg = _panel_instance.config();
+            cfg.pin_cs = 5;
+            cfg.pin_rst = 23;
+            cfg.pin_busy = -1;
+            cfg.panel_width = 135;
+            cfg.panel_height = 240;
+            cfg.offset_x = 52;
+            cfg.offset_y = 40;
+            cfg.offset_rotation = 0;
+            cfg.dummy_read_pixel = 8;
+            cfg.dummy_read_bits = 1;
+            cfg.readable = true;
+            cfg.invert = true;
+            cfg.rgb_order = false;
+            cfg.dlen_16bit = false;
+            cfg.bus_shared = true;
+            _panel_instance.config(cfg);
+        }
+
+        {
+            auto cfg = _light_instance.config();
+            cfg.pin_bl = 4;
+            cfg.invert = false;
+            cfg.freq = 44100;
+            cfg.pwm_channel = 7;
+            _light_instance.config(cfg);
+            _panel_instance.setLight(&_light_instance);
+        }
+
+        setPanel(&_panel_instance);
+    }
+};
+#endif
+
+#endif // TILTBRIDGE_LOVYAN_CONFIG_H

--- a/src/sendData.cpp
+++ b/src/sendData.cpp
@@ -256,8 +256,6 @@ bool dataSendHandler::send_to_grainfather()
         send_grainfather = false;
         send_lock = true;
 
-        Log.verbose(F("Calling send to Grainfather.\r\n"));
-
         // Loop through each of the tilt colors cached by tilt_scanner, sending
         // data for each of the active tilts
         tilt_scanner.drop_expired_tilts();
@@ -266,6 +264,7 @@ bool dataSendHandler::send_to_grainfather()
             if (strlen(config.grainfatherURL[th.m_color].link) == 0)
                 continue;
 
+            Log.verbose(F("Calling send to Grainfather.\r\n"));
             char gravity[10];
             char temp[6];
             JsonDocument j;

--- a/src/tilt/tiltHydrometer.cpp
+++ b/src/tilt/tiltHydrometer.cpp
@@ -31,14 +31,14 @@ const char* api_color_names[] = {
 };
 
 const uint32_t tilt_text_colors[] = {
-    0xF800, // Red
-    0x07E0, // Green
-    0xFFFF, // Black (white)
-    0x780F, // Purple
-    0xBAA0, // Orange (hook 'em)
-    0x001F, // Blue
-    0xFFE0, // Yellow
-    0xFE19  // Pink
+    0xFF0000, // Red
+    0x00FF00, // Green
+    0xFFFFFF, // Black (white)
+    0xCC00CC, // Purple
+    0xBD5500, // Orange (hook 'em)
+    0x0000FF, // Blue
+    0xFFFF00, // Yellow
+    0xFFC2CE  // Pink
 };
 
 tiltHydrometer::tiltHydrometer(NimBLEAddress address, uint8_t color)


### PR DESCRIPTION
Although I've had lots of success with Bodmer's tft_eSPI library in the past for displays other than OLED, unfortunately it appears to no longer be maintained. This PR switches TiltBrige to use a new display library that is actively maintained.