### PR TITLE
Wifi_dropout

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ v2.0.0 - Unreleased - New UI & Fermentrack 2 Support
 - Migrate from asynchronous to synchronous HTTP server
 - Upgrade to latest upstream frameworks/libraries
 - Add supprot for InfluxDB 2.x as a data target
+- Refactor WiFi reconnection logic
 
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,7 @@ monitor_rts = 1
 
 build_flags =                           ; Do not use spaces around the "=" here, will give you a builder not found error
     !python tools/git_rev.py            ; Pick up git information for version (disabled), branch, and commit (in version.cpp)
-    -D PIO_SRC_TAG="2.0.0-alpha6"                ; Increment versions shown in about.htm page (from version.cpp)
+    -D PIO_SRC_TAG="2.0.0-alpha7"                ; Increment versions shown in about.htm page (from version.cpp)
     ; BLE Settings:
     ;-D CONFIG_SW_COEXIST_PREFERENCE_BALANCED=1
     -D CONFIG_BT_NIMBLE_ROLE_PERIPHERAL_DISABLED=1   ; Disable NimBLE Server

--- a/src/bridge_lcd.cpp
+++ b/src/bridge_lcd.cpp
@@ -158,9 +158,7 @@ uint8_t bridge_lcd::display_next() {
 
     if (WiFi.status() == WL_CONNECTED) {
         displaying_wifi_dc_screen = false;
-    }
-
-    if (displaying_wifi_dc_screen) {
+    } else if (displaying_wifi_dc_screen) {
         // If we're displaying the wifi dc screen, stay on it. 
         return 1;
     }

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -148,20 +148,24 @@ void reconnectWiFi() {
             // First time we noticed the WiFi is out
             Log.notice(F("WiFi is disconnected, reconnecting. (%d/%d)" CR), WLcount, MAX_CONNECT_ATTEMPTS);
             lcd.display_wifi_disconnected_screen();
-            WiFi.begin();
+            // WiFi.begin();
             delay(1000); // Ensuring the "disconnected" screen appears for at least one second
         } else if(WLNextAt >= esp_timer_get_time()) {
             // Haven't hit the timer for the next reconnect attempt - just return
             return;
+        }
+
+        // Try to reconnect
+        WiFi.reconnect();
         WLNextAt = esp_timer_get_time() + (1000 * TIME_BETWEEN_ATTEMPTS);
+        ++WLcount;
 
         // Check if we reconnected
         if (WiFi.status() != WL_CONNECTED) {
-            if (WLcount < MAX_CONNECT_ATTEMPTS) {
+            if (WLcount <= MAX_CONNECT_ATTEMPTS) {
                 // Not reconnected, but still have attempts left to reconnect
                 // printDot(true);
                 Log.notice(F("WiFi is still disconnected. (%d/%d)" CR), WLcount, MAX_CONNECT_ATTEMPTS);
-                ++WLcount;
             } else {
                 // We failed to reconnect.
                 lcd.display_wifi_reconnect_failed();

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -2,6 +2,7 @@
 #include <ESPmDNS.h>
 #include <LCBUrl.h>
 #include <WiFiManager.h>
+#include <esp_timer.h>
 
 #include "bridge_lcd.h"
 #include "jsonconfig.h"
@@ -74,7 +75,7 @@ void initWiFi() {
     wm.setConfigPortalTimeout(5 * 60);              // Timeout portal in 5 mins
 
     wm.setHostname(config.mdnsID);  // Allow DHCP to get proper name
-    // wm.setWiFiAutoReconnect(true);  // Enable auto reconnect (should remove need for reconnectWiFi())
+    // wm.setWiFiAutoReconnect(true);  // Enable auto reconnect (should remove need for reconnectWiFi()) - Note, this doesn't seem to be supported for anything other than ESP8266, so disabling it here in favor of the manual implementation in the loop
     wm.setWiFiAPChannel(1);         // Pick the most common channel, safe for all countries
     wm.setCleanConnect(true);       // Always disconnect before connecting
     // Commenting out setCountry until https://github.com/tzapu/WiFiManager/issues/1309 is fixed
@@ -135,10 +136,10 @@ void initWiFi() {
     lcd.display_wifi_success_screen(mdns_url, ip_address_url);
 }
 
-#define MAX_CONNECT_ATTEMPTS 200
-#define TIME_BETWEEN_ATTEMPTS 3000  // Minimum time between attempts
+#define MAX_CONNECT_ATTEMPTS 50
+#define TIME_BETWEEN_ATTEMPTS 6000  // Minimum time between attempts (milliseconds)
 uint8_t WLcount = 0;
-unsigned long WLNextAt = 0;
+int64_t WLNextAt = 0;
 
 void reconnectWiFi() {
     if (WiFi.status() != WL_CONNECTED) {
@@ -149,14 +150,10 @@ void reconnectWiFi() {
             lcd.display_wifi_disconnected_screen();
             WiFi.begin();
             delay(1000); // Ensuring the "disconnected" screen appears for at least one second
-        } else if(WLNextAt >= millis()) {
+        } else if(WLNextAt >= esp_timer_get_time()) {
             // Haven't hit the timer for the next reconnect attempt - just return
             return;
-        } else {
-            WiFi.reconnect();
-            delay(100);
-        }
-        WLNextAt = millis() + TIME_BETWEEN_ATTEMPTS;
+        WLNextAt = esp_timer_get_time() + (1000 * TIME_BETWEEN_ATTEMPTS);
 
         // Check if we reconnected
         if (WiFi.status() != WL_CONNECTED) {

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -51,6 +51,16 @@ void mdnsReset() {
 void initWiFi() {
 
     WiFi.mode(WIFI_STA); // Explicitly set mode, ESP defaults to STA+AP
+    WiFi.setSleep(WIFI_PS_NONE); // Disable WiFi power saving for better stability
+
+    // Set up WiFi event handlers for better diagnostics
+    WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
+        Log.warning(F("WiFi disconnected, reason: %d\r\n"), info.wifi_sta_disconnected.reason);
+    }, ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+
+    WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
+        Log.notice(F("WiFi connected, IP: %s\r\n"), WiFi.localIP().toString().c_str());
+    }, ARDUINO_EVENT_WIFI_STA_GOT_IP);
 
     WiFiManager wm;
 #if ARDUINO_LOG_LEVEL == 6

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -27,11 +27,10 @@ void apCallback(WiFiManager *myWiFiManager) {
 void disconnectWiFi() {
     Log.notice(F("Resetting WiFi settings via disconnectWiFi()\r\n"));
     WiFi.mode(WIFI_AP_STA);
-    WiFi.persistent(true);
+    WiFi.persistent(true);  // This is implicit at startup, but I want to set it explicitly here to ensure credentials are deleted
     WiFi.disconnect(true, true);
     WiFi.begin("0","0");  // Fixes a bug where WiFi.disconnect() sometimes won't always clear the settings
-    WiFi.persistent(false);
-    vTaskDelay(1000);
+    vTaskDelay(1000);  // Give everything a moment to settle before resetting
     ESP.restart();
 }
 


### PR DESCRIPTION
Fixes a handful of potential edge cases that could affect WiFi reconnection success. Also disables modem sleep to hopefully prevent disconnects in the first place. 