### PR TITLE
Add ESP32 Cheap Yellow Display (CYD) support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -149,6 +149,37 @@ lib_deps =
 build_type = ${common.build_type}
 
 
+[env:cyd]   ; ESP32 Cheap Yellow Display (ESP32-2432S028)
+; 2.8" ILI9341 320x240 TFT with XPT2046 resistive touch
+; https://github.com/witnessmenow/ESP32-Cheap-Yellow-Display
+board = esp32dev
+platform = ${common.platform}
+framework = ${common.framework}
+board_build.partitions = ${common.board_build.partitions}
+board_build.filesystem = ${common.board_build.filesystem}
+upload_speed = ${common.upload_speed}
+monitor_speed = ${common.monitor_speed}
+monitor_filters = ${common.monitor_filters}
+monitor_dtr = ${common.monitor_dtr}
+monitor_rts = ${common.monitor_rts}
+lib_compat_mode = ${common.lib_compat_mode}
+build_flags =
+    ${common.build_flags}
+    -D LCD_TFT=1
+    -D CYD=1
+    -D TFT_WIDTH=240
+    -D TFT_HEIGHT=320
+    -D SMOOTH_FONT=1
+    -D LOAD_GFXFF=1
+    -D TOUCH_CS=33
+    -D WIFI_RESET_BUTTON_GPIO=0
+    -D HARDWARE_VERSION="CYD"
+lib_deps =
+    ${common.lib_deps}
+    ${common.espi_lib_deps}
+build_type = ${common.build_type}
+
+
 [env:tft_espi]  ; TTGO TFT (USB-C) Board
 ; This is configured for a TTGO T-Display using the tft_espi drivers
 ; it should work for other tft_espi compatible displays, if you tweak

--- a/src/bridge_lcd_impl.cpp
+++ b/src/bridge_lcd_impl.cpp
@@ -207,7 +207,9 @@ void bridge_lcd::init() {
 
 #elif defined(LCD_TFT_ESPI) || defined(LCD_TFT)
     // Initialize appropriate LovyanGFX configuration based on hardware
-#if defined(LCD_TFT)
+#if defined(LCD_TFT) && defined(CYD)
+    tft = new LGFX_CYD();
+#elif defined(LCD_TFT)
     tft = new LGFX_D32_Pro();
 #elif defined(LCD_TFT_M5STICKC)
     {

--- a/src/lovyan_config.h
+++ b/src/lovyan_config.h
@@ -50,6 +50,89 @@ public:
     }
 };
 
+#elif defined(LCD_TFT) && defined(CYD)
+// Configuration class for ESP32 Cheap Yellow Display (ESP32-2432S028)
+// ILI9341 320x240 on HSPI, XPT2046 touch on VSPI
+class LGFX_CYD : public lgfx::LGFX_Device
+{
+    lgfx::Panel_ILI9341 _panel_instance;
+    lgfx::Bus_SPI _bus_instance;
+    lgfx::Light_PWM _light_instance;
+    lgfx::Touch_XPT2046 _touch_instance;
+
+public:
+    LGFX_CYD(void)
+    {
+        {
+            auto cfg = _bus_instance.config();
+            cfg.spi_host = HSPI_HOST;
+            cfg.spi_mode = 0;
+            cfg.freq_write = 40000000;
+            cfg.freq_read = 16000000;
+            cfg.spi_3wire = true;
+            cfg.use_lock = true;
+            cfg.dma_channel = SPI_DMA_CH_AUTO;
+            cfg.pin_sclk = 14;
+            cfg.pin_mosi = 13;
+            cfg.pin_miso = 12;
+            cfg.pin_dc = 2;
+            _bus_instance.config(cfg);
+            _panel_instance.setBus(&_bus_instance);
+        }
+
+        {
+            auto cfg = _panel_instance.config();
+            cfg.pin_cs = 15;
+            cfg.pin_rst = -1;
+            cfg.pin_busy = -1;
+            cfg.panel_width = 240;
+            cfg.panel_height = 320;
+            cfg.offset_x = 0;
+            cfg.offset_y = 0;
+            cfg.offset_rotation = 0;
+            cfg.dummy_read_pixel = 8;
+            cfg.dummy_read_bits = 1;
+            cfg.readable = true;
+            cfg.invert = false;
+            cfg.rgb_order = false;
+            cfg.dlen_16bit = false;
+            cfg.bus_shared = false;
+            _panel_instance.config(cfg);
+        }
+
+        {
+            auto cfg = _light_instance.config();
+            cfg.pin_bl = 21;
+            cfg.invert = false;
+            cfg.freq = 44100;
+            cfg.pwm_channel = 7;
+            _light_instance.config(cfg);
+            _panel_instance.setLight(&_light_instance);
+        }
+
+        {
+            auto cfg = _touch_instance.config();
+            cfg.x_min = 0;
+            cfg.x_max = 239;
+            cfg.y_min = 0;
+            cfg.y_max = 319;
+            cfg.pin_int = 36;
+            cfg.bus_shared = false;
+            cfg.offset_rotation = 0;
+            cfg.spi_host = VSPI_HOST;
+            cfg.freq = 1000000;
+            cfg.pin_sclk = 25;
+            cfg.pin_mosi = 32;
+            cfg.pin_miso = 39;
+            cfg.pin_cs = 33;
+            _touch_instance.config(cfg);
+            _panel_instance.setTouch(&_touch_instance);
+        }
+
+        setPanel(&_panel_instance);
+    }
+};
+
 #elif defined(LCD_TFT)
 // Configuration class for D32 Pro TFT (ILI9341)
 class LGFX_D32_Pro : public lgfx::LGFX_Device

--- a/src/wifi_setup.cpp
+++ b/src/wifi_setup.cpp
@@ -241,16 +241,9 @@ void initWiFi() {
     // wifi_manager handles its own provisioning teardown after the configured delay
     // (stop_provisioning_on_connect + provisioning_teardown_delay_ms)
 
-    // Sync mDNS name from wifi_manager's NVS storage to config
-    // The wifi_manager may have a user-configured value that differs from config default
-    char stored_mdns[32] = {0};
-    if (wifi_manager_get_var("mdns_name", stored_mdns, sizeof(stored_mdns)) == ESP_OK && strlen(stored_mdns) > 0) {
-        if (isValidHostName(stored_mdns) && strcmp(stored_mdns, config.mdnsID) != 0) {
-            Log.notice("Using stored mDNS name from WiFi manager: %s\r\n", stored_mdns);
-            strlcpy(config.mdnsID, stored_mdns, sizeof(config.mdnsID));
-            config.save();
-        }
-    }
+    // Sync mDNS name FROM config TO wifi_manager (config file is the source of truth).
+    // The on_var_changed callback handles the reverse direction for real-time changes.
+    wifi_manager_set_var("mdns_name", config.mdnsID);
 
     initMDNS();
 }


### PR DESCRIPTION
- Add new [env:cyd] build environment for ESP32-2432S028
- Add XPT2046 touch support on separate SPI bus (VSPI)
- Fix WiFiManager dependency (use tzapu fork; looks like the feature_asyncwebserver branch was deleted on your fork)
- ESPAsyncWebServer const compatibility (getParam() returns const AsyncWebParameter* instead of AsyncWebParameter*)

The me-no-dev/ESPAsyncWebServer repository was recently archived, and the project has migrated to [ESP32Async/ESPAsyncWebServer](https://github.com/ESP32Async/ESPAsyncWebServer). A future PR could update the dependency to the new location, but that's beyond the scope of this CYD support PR.